### PR TITLE
docs: improve the jsDocs regarding Control.isReady and Control.canTakeInitiative

### DIFF
--- a/src/commonControls/DateControl.ts
+++ b/src/commonControls/DateControl.ts
@@ -76,9 +76,9 @@ export interface DateControlProps extends ControlProps {
     /**
      * Determines if the Control must obtain a value.
      *
-     * If `true`:
-     *  - the Control report isReady() = false if no value has been obtained.
-     *  - the control will take the initiative when given the opportunity.
+     * - If `true` the Control will take initiative to elicit a value.
+     * - If `false` the Control will not take initiative to elicit a value, but the user
+     *   can provide one if they wish, e.g. "U: I would like this by Tuesday".
      */
     required?: boolean | ((input: ControlInput) => boolean);
 
@@ -86,9 +86,8 @@ export interface DateControlProps extends ControlProps {
      * Whether the Control has to obtain explicit confirmation of the value.
      *
      * If `true`:
-     *  - the Control will report `isReady() = false` if the value has not been
-     *    explicitly confirmed as correct by user.
-     *  - the Control will take the initiative when given the opportunity.
+     *  - the Control will take initiative to explicitly confirm the value with a yes/no
+     *    question.
      */
     confirmationRequired?: boolean | ((input: ControlInput) => boolean);
 

--- a/src/commonControls/NumberControl.ts
+++ b/src/commonControls/NumberControl.ts
@@ -73,9 +73,9 @@ export interface NumberControlProps extends ControlProps {
     /**
      * Determines if the Control must obtain a value.
      *
-     * If `true`:
-     *  - the Control report isReady() = false if no value has been obtained.
-     *  - the control will take the initiative when given the opportunity.
+     * - If `true` the Control will take initiative to elicit a value.
+     * - If `false` the Control will not take initiative to elicit a value, but the user
+     *   can provide one if they wish, e.g. "U: I would three of those".
      */
     required?: boolean | ((input: ControlInput) => boolean);
 
@@ -93,9 +93,8 @@ export interface NumberControlProps extends ControlProps {
      * Whether the Control has to obtain explicit confirmation of the value.
      *
      * If `true`:
-     *  - the Control will report `isReady() = false` if the value has not been
-     *    explicitly confirmed as correct by user.
-     *  - the Control will take the initiative when given the opportunity.
+     *  - the Control will take initiative to explicitly confirm the value with a yes/no
+     *    question.
      */
     confirmationRequired?: boolean | NumberConfirmationRequireFunction;
 

--- a/src/commonControls/ValueControl.ts
+++ b/src/commonControls/ValueControl.ts
@@ -82,9 +82,9 @@ export interface ValueControlProps extends ControlProps {
     /**
      * Determines if the Control must obtain a value.
      *
-     * If `true`:
-     *  - the Control report isReady() = false if no value has been obtained.
-     *  - the control will take the initiative when given the opportunity.
+     * - If `true` the Control will take initiative to elicit a value.
+     * - If `false` the Control will not take initiative to elicit a value, but the user
+     *   can provide one if they wish, e.g. "U: My favorite color is blue".
      */
     required?: boolean | ((input: ControlInput) => boolean);
 
@@ -92,9 +92,8 @@ export interface ValueControlProps extends ControlProps {
      * Whether the Control has to obtain explicit confirmation of the value.
      *
      * If `true`:
-     *  - the Control will report `isReady() = false` if the value has not been
-     *    explicitly confirmed as correct by user.
-     *  - the Control will take the initiative when given the opportunity.
+     *  - the Control will take initiative to explicitly confirm the value with a yes/no
+     *    question.
      */
     confirmationRequired?: boolean | ((input: ControlInput) => boolean);
 

--- a/src/commonControls/dateRangeControl/DateRangeControl.ts
+++ b/src/commonControls/dateRangeControl/DateRangeControl.ts
@@ -125,9 +125,9 @@ export interface DateRangeControlProps extends ContainerControlProps {
     /**
      * Determines if the Control must obtain a value.
      *
-     * If `true`:
-     *  - the Control report isReady() = false if no value has been obtained.
-     *  - the control will take the initiative when given the opportunity.
+     * - If `true` the Control will take initiative to elicit a value.
+     * - If `false` the Control will not take initiative to elicit a value, but the user
+     *   can provide one if they wish, e.g. "U: I need it between Monday and Friday".
      */
     required?: boolean | ((input: ControlInput) => boolean);
 
@@ -135,9 +135,8 @@ export interface DateRangeControlProps extends ContainerControlProps {
      * Whether the Control has to obtain explicit confirmation of the value.
      *
      * If `true`:
-     *  - the Control will report `isReady() = false` if the value has not been
-     *    explicitly confirmed as correct by user.
-     *  - the Control will take the initiative when given the opportunity.
+     *  - the Control will take initiative to explicitly confirm the value with a yes/no
+     *    question.
      */
     confirmationRequired?: boolean | ((input: ControlInput) => boolean);
 

--- a/src/commonControls/listControl/ListControl.ts
+++ b/src/commonControls/listControl/ListControl.ts
@@ -104,9 +104,9 @@ export interface ListControlProps extends ControlProps {
     /**
      * Determines if the Control must obtain a value.
      *
-     * If `true`:
-     *  - the Control report isReady() = false if no value has been obtained.
-     *  - the control will take the initiative when given the opportunity.
+     * - If `true` the Control will take initiative to elicit a value.
+     * - If `false` the Control will not take initiative to elicit a value, but the user
+     *   can provide one if they wish, e.g. "U: My favorite color is blue".
      */
     required?: boolean | ((input: ControlInput) => boolean);
 
@@ -114,9 +114,8 @@ export interface ListControlProps extends ControlProps {
      * Whether the Control has to obtain explicit confirmation of the value.
      *
      * If `true`:
-     *  - the Control will report `isReady() = false` if the value has not been
-     *    explicitly confirmed as correct by user.
-     *  - the Control will take the initiative when given the opportunity.
+     *  - the Control will take initiative to explicitly confirm the value with a yes/no
+     *    question.
      */
     confirmationRequired?: boolean | ((input: ControlInput) => boolean);
 


### PR DESCRIPTION
## Description
The comment on `Control.isReady` was incorrect.  Also the comments on individual control's `isReady` and `canTakeInitiative` methods weren't very clear.  This PR correct the error and improves the descriptions.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Docs(Add new document content)
- [ ] Translate Docs(Translate document content)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://https://github.com/alexa/ask-sdk-controls/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
