### PR TITLE
chore: force upgrade of highlight.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
         "tsc-watch": "^4.2.3",
         "typedoc": "^0.17.6",
         "typedoc-neo-theme": "^1.0.8",
-        "typescript": "^3.9.5"
+        "typescript": "^3.9.5",
+        "highlight.js": ">=10.4.1"
     },
     "husky": {
         "hooks": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Dependabot indicates that highlight.js should be forced to version >=10.4.1 
This fix makes sure we don't lose it if package-lock.json gets recreated.

## Checklist
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://https://github.com/alexa/ask-sdk-controls/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement

