### PR TITLE
docs: correct generated file name for Spanish locale

### DIFF
--- a/doc/userGuide.md
+++ b/doc/userGuide.md
@@ -2459,7 +2459,7 @@ Use new translations at build time by updating the interaction model generator s
 2.     .buildCoreModelForControls(
 3.         new MyControlManager( {locale: 'es-ES', i18nResources: myResources }))
 4.     .withInvocationName('my invocation phrase')
-5.     .buildAndWrite('en-US-generated.json');
+5.     .buildAndWrite('es-ES-generated.json');
 6. console.log('done.');
 ```
 


### PR DESCRIPTION
## Description
The example for generating interaction model in case of Spanish locale uses wrong language code for file name.

## Motivation and Context
Correct the example.

## Testing
No testing is required.

## Screenshots (if appropriate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Docs(Add new document content)
- [ ] Translate Docs(Translate document content)

## Checklist
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://https://github.com/alexa/ask-sdk-controls/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
