### PR TITLE
Fix #55 - QuestionnaireControl drops user inputs

### DIFF
--- a/demo/QuestionnaireControl/src/index.ts
+++ b/demo/QuestionnaireControl/src/index.ts
@@ -61,6 +61,21 @@ export namespace MultipleLists {
                             submitButtonText: 'Next >',
                         }),
                     },
+                    prompts: {
+                        questionnaireCompleted: () => '',
+                        questionAnsweredAct: (act, input) =>
+                            /* Demonstrate a contextual prompt. This skips voice feedback
+                         when the screen provides sufficient feedback (which is true for
+                         all questions except the last) */
+                            `${
+                                act.payload.questionId !== 'cough' /* && APL device  */
+                                    ? ''
+                                    : act.payload.renderedChoice +
+                                      ' for ' +
+                                      act.payload.renderedQuestionShortForm +
+                                      '.'
+                            }`,
+                    },
                 }),
             );
 

--- a/demo/QuestionnaireControl/test/questionnaireDemo.spec.ts
+++ b/demo/QuestionnaireControl/test/questionnaireDemo.spec.ts
@@ -51,7 +51,7 @@ suite('Questionnaire Demo skill', () => {
             invoker,
             'U: yes',
             TestInput.of(IntentBuilder.of('AMAZON.YesIntent')),
-            'A: Great, thank you. Do you have a sore foot?',
+            'A: yes for cough. Do you have a sore foot?',
         );
 
         // going back to change an answer.
@@ -64,7 +64,7 @@ suite('Questionnaire Demo skill', () => {
                     target: 'cough',
                 }),
             ),
-            'A: OK, no for cough. Great, thank you. Do you have a sore foot?',
+            'A: no for cough. Do you have a sore foot?',
         );
 
         expect(requestHandler.getSerializableControlStates().healthScreen.value).deep.equals({
@@ -127,7 +127,7 @@ suite('Questionnaire Demo skill', () => {
             invoker,
             'U: I cough all the time',
             TestInput.of(GeneralControlIntent.of({ feedback: 'yes', target: 'cough' })),
-            'A: OK, yes for cough. Do you frequently have a headache?',
+            'A: yes for cough. Do you frequently have a headache?',
         );
 
         expect(requestHandler.getSerializableControlStates().healthScreen.value).deep.equals({

--- a/src/commonControls/questionnaireControl/QuestionnaireControlBuiltIns.ts
+++ b/src/commonControls/questionnaireControl/QuestionnaireControlBuiltIns.ts
@@ -149,23 +149,46 @@ export namespace QuestionnaireControlAPLPropsBuiltIns {
                         radioButtonColor: '${radioButtonColor}',
                         onPress: [
                             {
-                                type: 'SetValue',
-                                property: 'selectedIndex',
-                                value: '${selectedIndex == idx ? -1 : idx}',
-                            },
-                            {
-                                type: 'SetValue',
-                                componentId: 'debugText',
-                                property: 'text',
-                                value: 'Question: ${questionId}  Selected:${selectedIndex}',
-                            },
-                            {
-                                type: 'SendEvent',
-                                arguments: [
-                                    '${wrapper.general.controlId}',
-                                    'radioClick',
-                                    '${questionId}',
-                                    '${selectedIndex}',
+                                type: 'Sequential',
+
+                                /* Note: all multi-command  actions should go on custom sequencer, else commands can be lost on user press.
+                                 * https://developer.amazon.com/en-US/docs/alexa/alexa-presentation-language/apl-commands.html#normal-mode
+                                 */
+                                sequencer: 'CustomSequencer',
+                                commands: [
+                                    {
+                                        type: 'SetValue',
+                                        property: 'selectedIndex',
+                                        value: '${selectedIndex == idx ? -1 : idx}',
+                                    },
+                                    {
+                                        type: 'SetValue',
+                                        componentId: 'debugText',
+                                        property: 'text',
+                                        value: 'Question: ${questionId}  Selected:${selectedIndex}',
+                                    },
+                                    {
+                                        type: 'SetValue',
+                                        componentId: 'root',
+                                        property: 'disableContent',
+                                        value: true,
+                                    },
+                                    {
+                                        type: 'SetValue',
+                                        componentId: 'root',
+                                        property: 'enableWaitIndicator',
+                                        value: true,
+                                        delay: 1370,
+                                    },
+                                    {
+                                        type: 'SendEvent',
+                                        arguments: [
+                                            '${wrapper.general.controlId}',
+                                            'radioClick',
+                                            '${questionId}',
+                                            '${selectedIndex}',
+                                        ],
+                                    },
                                 ],
                             },
                         ],
@@ -269,10 +292,11 @@ export namespace QuestionnaireControlAPLPropsBuiltIns {
                     type: 'Container',
                     width: '100vw',
                     height: '100vh',
+                    disabled: '${disableContent}',
                     bind: [
                         {
                             name: 'disableContent',
-                            value: false,
+                            value: '${wrapper.disableScreen}',
                             type: 'boolean',
                         },
                         {
@@ -364,31 +388,41 @@ export namespace QuestionnaireControlAPLPropsBuiltIns {
                                 type: 'Sequential',
                                 commands: [
                                     {
-                                        type: 'SetValue',
-                                        componentId: 'debugText',
-                                        property: 'text',
-                                        value: 'Complete',
-                                    },
-                                    {
-                                        type: 'SetValue',
-                                        componentId: 'root',
-                                        property: 'disableContent',
-                                        value: true,
-                                    },
-                                    {
-                                        type: 'SendEvent',
-                                        arguments: ['${wrapper.general.controlId}', 'complete'],
-                                    },
-                                    {
-                                        type: 'SetValue',
-                                        componentId: 'root',
-                                        property: 'enableWaitIndicator',
-                                        value: true,
-                                        delay: 1370,
+                                        type: 'Sequential',
+                                        /* Note: all multi-command  actions should go on custom sequencer, else commands can be lost on user press.
+                                         * https://developer.amazon.com/en-US/docs/alexa/alexa-presentation-language/apl-commands.html#normal-mode
+                                         */
+                                        sequencer: 'CustomSequencer',
+                                        commands: [
+                                            {
+                                                type: 'SetValue',
+                                                componentId: 'debugText',
+                                                property: 'text',
+                                                value: 'Complete',
+                                            },
+                                            {
+                                                type: 'SetValue',
+                                                componentId: 'root',
+                                                property: 'disableContent',
+                                                value: true,
+                                            },
+                                            {
+                                                type: 'SendEvent',
+                                                arguments: ['${wrapper.general.controlId}', 'complete'],
+                                            },
+                                            {
+                                                type: 'SetValue',
+                                                componentId: 'root',
+                                                property: 'enableWaitIndicator',
+                                                value: true,
+                                                delay: 1370,
+                                            },
+                                        ],
                                     },
                                 ],
                             },
                         },
+
                         {
                             type: 'AlexaProgressDots',
                             position: 'absolute',

--- a/src/commonControls/questionnaireControl/QuestionnaireControlBuiltIns.ts
+++ b/src/commonControls/questionnaireControl/QuestionnaireControlBuiltIns.ts
@@ -296,7 +296,7 @@ export namespace QuestionnaireControlAPLPropsBuiltIns {
                     bind: [
                         {
                             name: 'disableContent',
-                            value: '${wrapper.disableScreen}',
+                            value: false,
                             type: 'boolean',
                         },
                         {

--- a/src/responseGeneration/ControlResponseBuilder.ts
+++ b/src/responseGeneration/ControlResponseBuilder.ts
@@ -300,6 +300,15 @@ export class ControlResponseBuilder implements ResponseBuilder {
         this.displayUsed = true;
     }
 
+    addAPLExecuteCommandsDirective(token: string, commands: interfaces.alexa.presentation.apl.Command[]) {
+        this.coreBuilder.addDirective({
+            type: 'Alexa.Presentation.APL.ExecuteCommands',
+            token,
+            commands,
+        });
+        this.displayUsed = true;
+    }
+
     /**
      * Builds and returns the complete response.
      */

--- a/src/responseGeneration/ControlResponseBuilder.ts
+++ b/src/responseGeneration/ControlResponseBuilder.ts
@@ -91,7 +91,7 @@ export class ControlResponseBuilder implements ResponseBuilder {
      * Concatenates the fragments with a single space between each.
      */
     getPrompt(): string {
-        return this.promptFragments.join(' ');
+        return this.promptFragments.filter((x) => x !== '').join(' ');
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Closes #55 

## Description
To avoid the user having their APL inputs lost due to racing UserEvents, this change disables the APL input widgets until the previous UserEvent has been fully processed.


## Motivation and Context
https://github.com/alexa/ask-sdk-controls/issues/55

## Testing
Manual testing with device simulator and live devices.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] UX change - The default user experience is altered
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs(Add new document content)
- [ ] Translate Docs(Translate document content)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License
- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

[issues]: https://https://github.com/alexa/ask-sdk-controls/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
