### PR TITLE
feat: builtin APL support for both blocking and non-blocking UI

### DIFF
--- a/demo/QuestionnaireControl/src/index.ts
+++ b/demo/QuestionnaireControl/src/index.ts
@@ -56,9 +56,8 @@ export namespace MultipleLists {
                         confirmationRequired: false,
                     },
                     apl: {
-                        askQuestion: QuestionnaireControlAPLPropsBuiltIns.defaultAskQuestion({
-                            title: 'Do you have these symptoms?',
-                            submitButtonText: 'Next >',
+                        askQuestion: QuestionnaireControlAPLPropsBuiltIns.DefaultAskQuestion({
+                            radioButtonPressesBlockUI: false,
                         }),
                     },
                     prompts: {

--- a/src/commonControls/listControl/ListControl.ts
+++ b/src/commonControls/listControl/ListControl.ts
@@ -368,7 +368,7 @@ export class ListControlPromptProps {
 export type AplContent = { document: { [key: string]: any }; dataSource: { [key: string]: any } };
 export type AplContentFunc = (control: ListControl, input: ControlInput) => AplContent;
 export type AplDocumentPropNewStyle = AplContent | AplContentFunc;
-export type AplRenderComponentFunc = (
+export type ListControlAplRenderComponentFunc = (
     control: ListControl,
     props: ListAPLComponentProps,
     input: ControlInput,
@@ -406,7 +406,7 @@ export class ListControlAPLProps {
      *
      * Default: ListControlComponentAPLBuiltIns.TextListRenderer.default
      */
-    renderComponent?: AplRenderComponentFunc;
+    renderComponent?: ListControlAplRenderComponentFunc;
 }
 
 /**

--- a/src/commonControls/numberControl/NumberControl.ts
+++ b/src/commonControls/numberControl/NumberControl.ts
@@ -289,7 +289,7 @@ export type AplContentFunc = (
     input: ControlInput,
 ) => AplContent | Promise<AplContent>;
 export type AplDocumentPropNewStyle = AplContent | AplContentFunc;
-export type AplRenderComponentFunc = (
+export type NumberControlAplRenderComponentFunc = (
     control: NumberControl,
     props: NumberControlAPLComponentProps,
     input: ControlInput,
@@ -332,7 +332,7 @@ export class NumberControlAPLProps {
      *
      * Default: NumberControlAPLComponentBuiltIns.ModalKeyPadRender.default
      */
-    renderComponent?: AplRenderComponentFunc;
+    renderComponent?: NumberControlAplRenderComponentFunc;
 }
 
 /**

--- a/src/commonControls/questionnaireControl/QuestionnaireControl.ts
+++ b/src/commonControls/questionnaireControl/QuestionnaireControl.ts
@@ -372,8 +372,11 @@ export class QuestionnaireControlPromptProps {
 
 //TODO: centralize these types.
 export type AplContent = { document: any; dataSource: any };
-export type AplContentFunc = (control: QuestionnaireControl, input: ControlInput) => AplContent;
-export type AplDocumentPropNewStyle = AplContent | AplContentFunc;
+export type QuestionnaireControlAplDocumentPropNewStyle = AplContent | QuestionnaireControlAplContentFunc;
+export type QuestionnaireControlAplContentFunc = (
+    control: QuestionnaireControl,
+    input: ControlInput,
+) => AplContent;
 
 /**
  * Props associated with the APL produced by QuestionnaireControl.
@@ -388,8 +391,17 @@ export class QuestionnaireControlAPLProps {
 
     /**
      * Custom APL to show all questions while asking one in particular.
+     * 
+     * Default:  
+```
+       QuestionnaireControlAPLPropsBuiltIns.DefaultAskQuestion({
+          title: 'Please select...', 
+          submitButtonText: 'Submit >',
+          radioButtonPressesBlockUI: true
+        }
+```
      */
-    askQuestion: AplDocumentPropNewStyle;
+    askQuestion?: QuestionnaireControlAplDocumentPropNewStyle;
 }
 
 export type QuestionnaireUserAnswers = {
@@ -602,9 +614,10 @@ export class QuestionnaireControl extends Control implements InteractionModelCon
             },
             apl: {
                 enabled: true,
-                askQuestion: QuestionnaireControlAPLPropsBuiltIns.defaultAskQuestion({
+                askQuestion: QuestionnaireControlAPLPropsBuiltIns.DefaultAskQuestion({
                     title: undefined, // the default is wired up in defaultAskQuestion()
                     submitButtonText: undefined, // the default is wired up in defaultAskQuestion()
+                    radioButtonPressesBlockUI: true,
                 }),
             },
             inputHandling: {
@@ -1272,8 +1285,13 @@ export class QuestionnaireControl extends Control implements InteractionModelCon
         return deepRequiredContent;
     }
 
-    private evaluateAPLPropNewStyle(prop: AplDocumentPropNewStyle, input: ControlInput): AplContent {
-        return typeof prop === 'function' ? (prop as AplContentFunc).call(this, this, input) : prop;
+    private evaluateAPLPropNewStyle(
+        prop: QuestionnaireControlAplDocumentPropNewStyle,
+        input: ControlInput,
+    ): AplContent {
+        return typeof prop === 'function'
+            ? (prop as QuestionnaireControlAplContentFunc).call(this, this, input)
+            : prop;
     }
 
     // tsDoc - see ControlStateDiagramming

--- a/src/commonControls/questionnaireControl/QuestionnaireControl.ts
+++ b/src/commonControls/questionnaireControl/QuestionnaireControl.ts
@@ -615,8 +615,8 @@ export class QuestionnaireControl extends Control implements InteractionModelCon
             apl: {
                 enabled: true,
                 askQuestion: QuestionnaireControlAPLPropsBuiltIns.DefaultAskQuestion({
-                    title: undefined, // the default is wired up in defaultAskQuestion()
-                    submitButtonText: undefined, // the default is wired up in defaultAskQuestion()
+                    title: undefined, // the default is wired up in DefaultAskQuestion()
+                    submitButtonText: undefined, // the default is wired up in DefaultAskQuestion()
                     radioButtonPressesBlockUI: true,
                 }),
             },

--- a/src/commonControls/questionnaireControl/QuestionnaireControlBuiltIns.ts
+++ b/src/commonControls/questionnaireControl/QuestionnaireControlBuiltIns.ts
@@ -53,14 +53,50 @@ export namespace QuestionnaireControlAPLPropsBuiltIns {
          * Default: false
          */
         debug?: boolean;
+
+        /**
+         * Whether the Radio buttons have blocking behavior.
+         *
+         * *Default: true*
+         *
+         * When true, all UI buttons are disabled (blocked) until processing of preceding
+         * radio button press is complete. If the processing takes significant time, a
+         * busy indicator is shown.
+         *
+         * Purpose:
+         * * Alexa does not serialize UserEvents and so there is a risk of UserEvents
+         *   racing if the user presses multiple buttons in quick succession, where "quick
+         *   succession" means "significantly faster than the UserEvent round-trip
+         *   processing latency".  Racing UserEvents can cause dropped state and/or
+         *   out-of-order event processing. This property provides the option to use
+         *   client-side-blocking to avoid the risks and costs of UserEvent races at the
+         *   expense of disabling and re-enabling the user input buttons.
+         *
+         * Pros and cons of blocking behavior:
+         *  * Pros: the user-interface is disabled which prevents users pressing more
+         *    buttons until the server is ready to accept them. This removes the
+         *    possibility of race-conditions.
+         *  * Cons: causes the input elements to be disabled (shown in grey and inactive)
+         *    for a short duration which may be distracting to the user.
+         *
+         * When to use?
+         *  * Consider using this if the latency for a UserEvent round trip is high, e.g.
+         *    greater than 400ms.
+         *  * Consider using this if the cost of dropped inputs is high compared to the UI
+         *    friction of disabling/enabling buttons.
+         *
+         * Additional notes:
+         * * The Done button always uses blocking behavior.
+         */
+        radioButtonPressesBlockUI?: boolean;
     }
 
-    export function defaultAskQuestion(
+    export function DefaultAskQuestion(
         props: DefaultAskQuestionProps,
     ): (control: QuestionnaireControl, input: ControlInput) => AplContent {
         return (control: QuestionnaireControl, input: ControlInput) => {
             return {
-                document: questionnaireDocumentGenerator(control, input),
+                document: aplDocumentCore(control, input, props.radioButtonPressesBlockUI ?? true),
                 dataSource: questionnaireDataSourceGenerator(control, input, props),
             };
         };
@@ -110,332 +146,336 @@ export namespace QuestionnaireControlAPLPropsBuiltIns {
             },
         };
     }
+}
 
-    /**
-     * The APL document to use when requesting a value
-     *
-     * Default: Questionnaire items shown as line items with radio buttons for selecting answer
-     */
-    export function questionnaireDocumentGenerator(control: QuestionnaireControl, input: ControlInput) {
-        const content = control.getQuestionnaireContent(input);
+/**
+ * An APL document generator to use when requesting a value
+ * Can produce both "blocking style" and "non-blocking style".
+ */
+function aplDocumentCore(control: QuestionnaireControl, input: ControlInput, blocking: boolean) {
+    const content = control.getQuestionnaireContent(input);
 
-        return {
-            type: 'APL',
-            version: '1.5',
-            import: [
-                {
-                    name: 'alexa-layouts',
-                    version: '1.2.0',
-                },
-            ],
-            layouts: {
-                AnswerButton: {
-                    parameters: [
+    return {
+        type: 'APL',
+        version: '1.5',
+        import: [
+            {
+                name: 'alexa-layouts',
+                version: '1.2.0',
+            },
+        ],
+        layouts: {
+            AnswerButton: {
+                parameters: [
+                    {
+                        name: 'idx',
+                        description: 'Index of this button within the group',
+                        type: 'number',
+                        default: 0,
+                    },
+                ],
+                items: {
+                    type: 'AlexaRadioButton',
+                    checked: '${idx == selectedIndex}',
+                    disabled: '${disableContent}',
+                    theme: '${theme}',
+                    accessibilityLabel: '${accessibilityLabel}',
+                    radioButtonHeight: '${radioButtonHeight}',
+                    radioButtonWidth: '${radioButtonWidth}',
+                    radioButtonColor: '${radioButtonColor}',
+                    onPress: [
                         {
-                            name: 'idx',
-                            description: 'Index of this button within the group',
-                            type: 'number',
-                            default: 0,
+                            type: 'Sequential',
+
+                            /* Note: all multi-command  actions should go on custom sequencer, else commands can be lost on user press.
+                             * https://developer.amazon.com/en-US/docs/alexa/alexa-presentation-language/apl-commands.html#normal-mode
+                             */
+                            sequencer: 'CustomSequencer',
+                            commands: [
+                                {
+                                    type: 'SetValue',
+                                    property: 'selectedIndex',
+                                    value: '${selectedIndex == idx ? -1 : idx}',
+                                },
+                                {
+                                    type: 'SetValue',
+                                    componentId: 'debugText',
+                                    property: 'text',
+                                    value: 'Question: ${questionId}  Selected:${selectedIndex}',
+                                },
+                                blocking
+                                    ? {
+                                          type: 'SetValue',
+                                          componentId: 'root',
+                                          property: 'disableContent',
+                                          value: true,
+                                      }
+                                    : undefined,
+                                blocking
+                                    ? {
+                                          type: 'SetValue',
+                                          componentId: 'root',
+                                          property: 'enableWaitIndicator',
+                                          value: true,
+                                          delay: 1370,
+                                      }
+                                    : undefined,
+                                {
+                                    type: 'SendEvent',
+                                    arguments: [
+                                        '${wrapper.general.controlId}',
+                                        'radioClick',
+                                        '${questionId}',
+                                        '${selectedIndex}',
+                                    ],
+                                },
+                            ],
                         },
                     ],
-                    items: {
-                        type: 'AlexaRadioButton',
-                        checked: '${idx == selectedIndex}',
-                        disabled: '${disableContent}',
-                        theme: '${theme}',
-                        accessibilityLabel: '${accessibilityLabel}',
-                        radioButtonHeight: '${radioButtonHeight}',
-                        radioButtonWidth: '${radioButtonWidth}',
-                        radioButtonColor: '${radioButtonColor}',
-                        onPress: [
+                },
+            },
+            QuestionRow: {
+                parameters: [
+                    {
+                        name: 'primaryText',
+                        description: 'Label',
+                        type: 'string',
+                        default: 'none',
+                    },
+                    {
+                        name: 'selectedIndex',
+                        description: 'Which choice is selected',
+                        type: 'number',
+                        default: -1,
+                    },
+                    {
+                        name: 'questionId',
+                        description: 'Which question does this row represent',
+                        type: 'string',
+                        default: 'none',
+                    },
+                    {
+                        name: 'theme',
+                        description:
+                            'Colors will be changed depending on the specified theme (light/dark). Defaults to dark theme.',
+                        type: 'string',
+                        default: 'dark',
+                    },
+                    {
+                        name: 'radioButtonHeight',
+                        description: 'Height of the radioButton',
+                        type: 'dimension',
+                        default: '@radioButtonDefaultHeight',
+                    },
+                    {
+                        name: 'radioButtonWidth',
+                        description: 'Width of the radioButton',
+                        type: 'dimension',
+                        default: '@radioButtonDefaultWidth',
+                    },
+                    {
+                        name: 'buttonColumnWidth',
+                        description: 'Width of the radioButton columns',
+                        type: 'dimension',
+                        default: '@radioButtonDefaultWidth',
+                    },
+                    {
+                        name: 'radioButtonColor',
+                        description: 'Selected color of the radioButton',
+                        type: 'color',
+                        default: "${theme != 'light' ? @colorAccent : '#1CA0CE'}",
+                    },
+                ],
+                items: [
+                    {
+                        type: 'Container',
+                        direction: 'row',
+                        items: [
                             {
-                                type: 'Sequential',
-
-                                /* Note: all multi-command  actions should go on custom sequencer, else commands can be lost on user press.
-                                 * https://developer.amazon.com/en-US/docs/alexa/alexa-presentation-language/apl-commands.html#normal-mode
-                                 */
-                                sequencer: 'CustomSequencer',
-                                commands: [
-                                    {
-                                        type: 'SetValue',
-                                        property: 'selectedIndex',
-                                        value: '${selectedIndex == idx ? -1 : idx}',
-                                    },
-                                    {
-                                        type: 'SetValue',
-                                        componentId: 'debugText',
-                                        property: 'text',
-                                        value: 'Question: ${questionId}  Selected:${selectedIndex}',
-                                    },
-                                    {
-                                        type: 'SetValue',
-                                        componentId: 'root',
-                                        property: 'disableContent',
-                                        value: true,
-                                    },
-                                    {
-                                        type: 'SetValue',
-                                        componentId: 'root',
-                                        property: 'enableWaitIndicator',
-                                        value: true,
-                                        delay: 1370,
-                                    },
-                                    {
-                                        type: 'SendEvent',
-                                        arguments: [
-                                            '${wrapper.general.controlId}',
-                                            'radioClick',
-                                            '${questionId}',
-                                            '${selectedIndex}',
-                                        ],
-                                    },
-                                ],
+                                type: 'Container',
+                                width: '${buttonColumnWidth}',
+                                items: {
+                                    type: 'AnswerButton',
+                                    width: '${radioButtonWidth}',
+                                    height: '${radioButtonHeight}',
+                                    alignSelf: 'center',
+                                    idx: 0,
+                                    questionId: '${id}',
+                                },
+                            },
+                            {
+                                type: 'Container',
+                                width: '${buttonColumnWidth}',
+                                items: {
+                                    type: 'AnswerButton',
+                                    width: '${radioButtonWidth}',
+                                    height: '${radioButtonHeight}',
+                                    alignSelf: 'center',
+                                    idx: 1,
+                                    questionId: '${id}',
+                                },
+                            },
+                            {
+                                type: 'Text',
+                                text: '${primaryText}',
+                                textAlignVertical: 'center',
                             },
                         ],
                     },
-                },
-                QuestionRow: {
-                    parameters: [
-                        {
-                            name: 'primaryText',
-                            description: 'Label',
-                            type: 'string',
-                            default: 'none',
-                        },
-                        {
-                            name: 'selectedIndex',
-                            description: 'Which choice is selected',
-                            type: 'number',
-                            default: -1,
-                        },
-                        {
-                            name: 'questionId',
-                            description: 'Which question does this row represent',
-                            type: 'string',
-                            default: 'none',
-                        },
-                        {
-                            name: 'theme',
-                            description:
-                                'Colors will be changed depending on the specified theme (light/dark). Defaults to dark theme.',
-                            type: 'string',
-                            default: 'dark',
-                        },
-                        {
-                            name: 'radioButtonHeight',
-                            description: 'Height of the radioButton',
-                            type: 'dimension',
-                            default: '@radioButtonDefaultHeight',
-                        },
-                        {
-                            name: 'radioButtonWidth',
-                            description: 'Width of the radioButton',
-                            type: 'dimension',
-                            default: '@radioButtonDefaultWidth',
-                        },
-                        {
-                            name: 'buttonColumnWidth',
-                            description: 'Width of the radioButton columns',
-                            type: 'dimension',
-                            default: '@radioButtonDefaultWidth',
-                        },
-                        {
-                            name: 'radioButtonColor',
-                            description: 'Selected color of the radioButton',
-                            type: 'color',
-                            default: "${theme != 'light' ? @colorAccent : '#1CA0CE'}",
-                        },
-                    ],
-                    items: [
-                        {
-                            type: 'Container',
-                            direction: 'row',
-                            items: [
-                                {
-                                    type: 'Container',
-                                    width: '${buttonColumnWidth}',
-                                    items: {
-                                        type: 'AnswerButton',
-                                        width: '${radioButtonWidth}',
-                                        height: '${radioButtonHeight}',
-                                        alignSelf: 'center',
-                                        idx: 0,
-                                        questionId: '${id}',
-                                    },
-                                },
-                                {
-                                    type: 'Container',
-                                    width: '${buttonColumnWidth}',
-                                    items: {
-                                        type: 'AnswerButton',
-                                        width: '${radioButtonWidth}',
-                                        height: '${radioButtonHeight}',
-                                        alignSelf: 'center',
-                                        idx: 1,
-                                        questionId: '${id}',
-                                    },
-                                },
-                                {
-                                    type: 'Text',
-                                    text: '${primaryText}',
-                                    textAlignVertical: 'center',
-                                },
-                            ],
-                        },
-                    ],
-                },
+                ],
             },
-            mainTemplate: {
-                parameters: ['wrapper'],
-                item: {
-                    id: 'root',
-                    type: 'Container',
-                    width: '100vw',
-                    height: '100vh',
-                    disabled: '${disableContent}',
-                    bind: [
-                        {
-                            name: 'disableContent',
-                            value: false,
-                            type: 'boolean',
+        },
+        mainTemplate: {
+            parameters: ['wrapper'],
+            item: {
+                id: 'root',
+                type: 'Container',
+                width: '100vw',
+                height: '100vh',
+                disabled: '${disableContent}',
+                bind: [
+                    {
+                        name: 'disableContent',
+                        value: false,
+                        type: 'boolean',
+                    },
+                    {
+                        name: 'enableWaitIndicator',
+                        value: false,
+                        type: 'boolean',
+                    },
+                ],
+                items: [
+                    {
+                        type: 'AlexaBackground',
+                    },
+                    {
+                        type: 'AlexaHeader',
+                        id: 'heading1',
+                        headerDivider: true,
+                        headerBackButton: '${wrapper.general.headerBackButton}',
+                        headerBackButtonCommand: {
+                            type: 'SendEvent',
+                            arguments: ['goBack'],
                         },
-                        {
-                            name: 'enableWaitIndicator',
-                            value: false,
-                            type: 'boolean',
-                        },
-                    ],
-                    items: [
-                        {
-                            type: 'AlexaBackground',
-                        },
-                        {
-                            type: 'AlexaHeader',
-                            id: 'heading1',
-                            headerDivider: true,
-                            headerBackButton: '${wrapper.general.headerBackButton}',
-                            headerBackButtonCommand: {
-                                type: 'SendEvent',
-                                arguments: ['goBack'],
+                        headerTitle: '${wrapper.general.headerTitle}',
+                        headerSubtitle: '${wrapper.general.headerSubtitle}',
+                    },
+                    {
+                        type: 'Container',
+                        paddingLeft: '@spacingMedium',
+                        direction: 'row',
+                        items: [
+                            {
+                                type: 'Text',
+                                style: 'textStyleHint',
+                                width: '${wrapper.general.buttonColumnWidth}',
+                                text: 'Yes',
+                                textAlign: 'center',
                             },
-                            headerTitle: '${wrapper.general.headerTitle}',
-                            headerSubtitle: '${wrapper.general.headerSubtitle}',
-                        },
-                        {
-                            type: 'Container',
-                            paddingLeft: '@spacingMedium',
-                            direction: 'row',
-                            items: [
-                                {
-                                    type: 'Text',
-                                    style: 'textStyleHint',
-                                    width: '${wrapper.general.buttonColumnWidth}',
-                                    text: 'Yes',
-                                    textAlign: 'center',
-                                },
-                                {
-                                    type: 'Text',
-                                    style: 'textStyleHint',
-                                    width: '${wrapper.general.buttonColumnWidth}',
-                                    text: 'No',
-                                    textAlign: 'center',
-                                },
-                                {
-                                    type: 'Text',
-                                    text: '${primaryText}',
-                                    textAlignVertical: 'center',
-                                },
-                            ],
-                        },
-                        {
-                            type: 'ScrollView',
-                            shrink: 1,
-                            grow: 1,
-                            items: [
-                                {
-                                    type: 'Sequence',
-                                    width: '100vw',
-                                    height: '80vh',
-                                    paddingLeft: '@spacingMedium',
-                                    data: '${wrapper.questionData}',
-                                    items: {
-                                        type: 'QuestionRow',
-                                        primaryText: '${data.primaryText}',
-                                        questionId: '${data.questionId}',
-                                        selectedIndex: '${data.selectedIndex}',
-                                        radioButtonColor: '${wrapper.general.radioButtonColor}',
-                                        radioButtonHeight: '${wrapper.general.radioButtonSize}',
-                                        radioButtonWidth: '${wrapper.general.radioButtonSize}',
-                                        buttonColumnWidth: '${wrapper.general.buttonColumnWidth}',
-                                    },
-                                },
-                            ],
-                        },
-                        {
-                            when: '${wrapper.general.debug}',
-                            position: 'absolute',
-                            bottom: '0vh',
-                        },
-                        {
-                            type: 'AlexaButton',
-                            id: 'nextButton',
-                            disabled: '${disableContent}',
-                            buttonText: '${wrapper.general.nextButtonText}',
-                            position: 'absolute',
-                            top: '10',
-                            right: '10',
-                            primaryAction: {
-                                type: 'Sequential',
-                                commands: [
-                                    {
-                                        type: 'Sequential',
-                                        /* Note: all multi-command  actions should go on custom sequencer, else commands can be lost on user press.
-                                         * https://developer.amazon.com/en-US/docs/alexa/alexa-presentation-language/apl-commands.html#normal-mode
-                                         */
-                                        sequencer: 'CustomSequencer',
-                                        commands: [
-                                            {
-                                                type: 'SetValue',
-                                                componentId: 'debugText',
-                                                property: 'text',
-                                                value: 'Complete',
-                                            },
-                                            {
-                                                type: 'SetValue',
-                                                componentId: 'root',
-                                                property: 'disableContent',
-                                                value: true,
-                                            },
-                                            {
-                                                type: 'SendEvent',
-                                                arguments: ['${wrapper.general.controlId}', 'complete'],
-                                            },
-                                            {
-                                                type: 'SetValue',
-                                                componentId: 'root',
-                                                property: 'enableWaitIndicator',
-                                                value: true,
-                                                delay: 1370,
-                                            },
-                                        ],
-                                    },
-                                ],
+                            {
+                                type: 'Text',
+                                style: 'textStyleHint',
+                                width: '${wrapper.general.buttonColumnWidth}',
+                                text: 'No',
+                                textAlign: 'center',
                             },
-                        },
+                            {
+                                type: 'Text',
+                                text: '${primaryText}',
+                                textAlignVertical: 'center',
+                            },
+                        ],
+                    },
+                    {
+                        type: 'ScrollView',
+                        shrink: 1,
+                        grow: 1,
+                        items: [
+                            {
+                                type: 'Sequence',
+                                width: '100vw',
+                                height: '80vh',
+                                paddingLeft: '@spacingMedium',
+                                data: '${wrapper.questionData}',
+                                items: {
+                                    type: 'QuestionRow',
+                                    primaryText: '${data.primaryText}',
+                                    questionId: '${data.questionId}',
+                                    selectedIndex: '${data.selectedIndex}',
+                                    radioButtonColor: '${wrapper.general.radioButtonColor}',
+                                    radioButtonHeight: '${wrapper.general.radioButtonSize}',
+                                    radioButtonWidth: '${wrapper.general.radioButtonSize}',
+                                    buttonColumnWidth: '${wrapper.general.buttonColumnWidth}',
+                                },
+                            },
+                        ],
+                    },
+                    {
+                        when: '${wrapper.general.debug}',
+                        position: 'absolute',
+                        bottom: '0vh',
+                    },
+                    {
+                        type: 'AlexaButton',
+                        id: 'nextButton',
+                        disabled: '${disableContent}',
+                        buttonText: '${wrapper.general.nextButtonText}',
+                        position: 'absolute',
+                        top: '10',
+                        right: '10',
+                        primaryAction: {
+                            type: 'Sequential',
+                            commands: [
+                                {
+                                    type: 'Sequential',
+                                    /* Note: all multi-command  actions should go on custom sequencer, else commands can be lost on user press.
+                                     * https://developer.amazon.com/en-US/docs/alexa/alexa-presentation-language/apl-commands.html#normal-mode
+                                     */
+                                    sequencer: 'CustomSequencer',
+                                    commands: [
+                                        {
+                                            type: 'SetValue',
+                                            componentId: 'debugText',
+                                            property: 'text',
+                                            value: 'Complete',
+                                        },
+                                        {
+                                            type: 'SetValue',
+                                            componentId: 'root',
+                                            property: 'disableContent',
+                                            value: true,
+                                        },
+                                        {
+                                            type: 'SendEvent',
+                                            arguments: ['${wrapper.general.controlId}', 'complete'],
+                                        },
 
-                        {
-                            type: 'AlexaProgressDots',
-                            position: 'absolute',
-                            display: "${enableWaitIndicator ? 'normal' : 'invisible'}",
-                            top: '50vh',
-                            right: '20dp',
-                            dotSize: '12dp',
-                            componentId: 'largeDotsId',
-                            spacing: '@spacingMedium',
+                                        {
+                                            type: 'SetValue',
+                                            componentId: 'root',
+                                            property: 'enableWaitIndicator',
+                                            value: true,
+                                            delay: 1370,
+                                        },
+                                    ],
+                                },
+                            ],
                         },
-                    ],
-                },
+                    },
+
+                    {
+                        type: 'AlexaProgressDots',
+                        position: 'absolute',
+                        display: "${enableWaitIndicator ? 'normal' : 'invisible'}",
+                        top: '50vh',
+                        right: '20dp',
+                        dotSize: '12dp',
+                        componentId: 'largeDotsId',
+                        spacing: '@spacingMedium',
+                    },
+                ],
             },
-        };
-    }
+        },
+    };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,7 @@ export {
     ListControlPromptProps,
     ListControlProps,
     ListControlState,
+    ListControlAplRenderComponentFunc,
 } from './commonControls/listControl/ListControl';
 export { ListControlAPLPropsBuiltIns } from './commonControls/listControl/ListControlAPL';
 export {
@@ -65,6 +66,8 @@ export {
     NumberControlPromptsProps,
     NumberControlProps,
     NumberControlState,
+    NumberControlAPLProps,
+    NumberControlAplRenderComponentFunc,
 } from './commonControls/numberControl/NumberControl';
 export * from './commonControls/questionnaireControl/QuestionnaireControl';
 export * from './commonControls/questionnaireControl/QuestionnaireControlBuiltIns';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`QuestionnaireControlBuiltins.DefaultAskQuestion` now offers a prop called `radioButtonPressesBlockUI` to select between blocking and non-blocking UI.  This gives developers easy access to the two styles that we have been asked for.

Video showing the UX in action and discussing the change: https://www.youtube.com/watch?v=bqW6lkrseMM

<!--- Describe your changes in detail -->

## Motivation and Context
The questionnaire control builtin APL was recently changed to have a block user-interface as users had reported issues with dropped input due to UserEvent racing.  This change gives the developer two builtins: one for blocking style and one for the original non-blocking style

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manual testing of the two modes in device simulator.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs(Add new document content)
- [ ] Translate Docs(Translate document content)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License
- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

[issues]: https://https://github.com/alexa/ask-sdk-controls/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
