### PR TITLE
fix: change in controlUtils to throw error in case of a conflict between multiple handlers

### DIFF
--- a/src/controls/Control.ts
+++ b/src/controls/Control.ts
@@ -57,7 +57,6 @@ export interface ControlInputHandler {
     canHandle: (this: Control, input: ControlInput) => boolean | Promise<boolean>;
     handle: (this: Control, input: ControlInput, resultBuilder: ControlResultBuilder) => void | Promise<void>;
 }
-
 export interface ControlInitiativeHandler {
     name: string;
     canTakeInitiative(input: ControlInput): boolean | Promise<boolean>;

--- a/src/utils/ControlUtils.ts
+++ b/src/utils/ControlUtils.ts
@@ -32,7 +32,7 @@ const log = new Logger('AskSdkControls:ControlUtils');
  */
 export async function evaluateInputHandlers(control: Control, input: ControlInput): Promise<boolean> {
     const stdHandlers = (control as any).standardInputHandlers ?? [];
-    const customHandlers = (control as any).props.inputHandling.customHandlingFuncs ?? [];
+    const customHandlers = ((control as any).props.inputHandling ?? []).customHandlingFuncs ?? [];
 
     const aplProps = (control as any).props.apl;
 

--- a/src/utils/ControlUtils.ts
+++ b/src/utils/ControlUtils.ts
@@ -53,9 +53,9 @@ export async function evaluateInputHandlers(control: Control, input: ControlInpu
     }
 
     if (matches.length > 1) {
-        log.error(
+        throw Error(
             `More than one handler matched. Handlers in a single control should be mutually exclusive. ` +
-                `Defaulting to the first. handlers: ${JSON.stringify(matches.map((x) => x.name))}`,
+                `handlers: ${JSON.stringify(matches.map((x) => x.name))}`,
         );
     }
 

--- a/test/scenarios.spec.ts
+++ b/test/scenarios.spec.ts
@@ -320,23 +320,13 @@ suite('== Custom Handler function scenarios ==', () => {
                 action: $.Action.Set,
             }),
         );
-        const spy = sinon.stub(Logger.prototype, 'error');
-        const result = new ControlResultBuilder(undefined!);
-        await rootControl.canHandle(input);
-        await rootControl.handle(input, result);
-
-        expect(
-            spy.calledOnceWith(
-                'More than one handler matched. Handlers in a single control should be mutually exclusive. Defaulting to the first. handlers: ["SetWithValue (built-in)","SetValue"]',
-            ),
-        ).eq(true);
-
-        spy.restore();
-
-        const dateControlState = findControlInTreeById(rootControl, 'dateControl');
-        expect(dateControlState.state.value).eq('2018');
-        expect(result.acts).length(1);
-        expect(result.acts[0]).instanceOf(ValueSetAct);
+        try {
+            await rootControl.canHandle(input);
+        } catch (e) {
+            expect(e.message).eq(
+                'More than one handler matched. Handlers in a single control should be mutually exclusive. handlers: ["SetWithValue (built-in)","SetValue"]',
+            );
+        }
     });
 });
 


### PR DESCRIPTION
Changed logic in ControlUtils to throw an error if multiple matching handlers are found. The skill developer should be aware of the conflicts and resolve the situation appropriately.

## Description
The previous version of the ControlUtils, in case of matching handlers, would log this event as an error and select the first matching handler. Changing this to throw an error instead.

## Motivation and Context
Simply logging the error could hide potential bigger issues in the skill code. Moreover, in case the conflict is between built ins and custom handlers, built ins will always win. This could be contrary to the skill developer's expectations.

## Testing
Added unit tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs(Add new document content)
- [ ] Translate Docs(Translate document content)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License
- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

[issues]: https://https://github.com/alexa/ask-sdk-controls/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
