### PR TITLE
fix: exported i18Init function on ControlManager

### DIFF
--- a/src/controls/ControlManager.ts
+++ b/src/controls/ControlManager.ts
@@ -372,7 +372,7 @@ function updateIMForControlTree(
  * @param locale - The locale to specialize to.
  * @param resources - Resources for all supported locales.
  */
-function i18nInit(locale: string, resources: Resource): void {
+export function i18nInit(locale: string, resources: Resource): void {
     if (!locale) {
         throw new Error('Please specify the language.');
     }


### PR DESCRIPTION
## Description
Exported i18Init function on ControlManager

## Motivation and Context
Recently one of the developer raised a concern of i18next module being undefined in the framework when a custom  controlManager is being defined and exported as a component on a new skill package which depends on both our framework and the component.
The skill's buildInteractionModel script when executed was not able to resolve locale specific slotValues to be added to interactionModel due to i18next local library module of the component being initialized rather than framework i18next module causing issues.
Exporting the i18Init() from the framework fixed the issue, where the i18next module reference of ask-sdk-controls was being pickup always since it is invoked from the ControlManager Constructor.

## Testing
- npm run release success.
- Created a skill component by defining a custom ControlManager and exported it.
- Created and tested a new skill with referencing exported ControlManager to build the interactionModel and it succeeded. 
## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs(Add new document content)
- [ ] Translate Docs(Translate document content)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License
- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

[issues]: https://https://github.com/alexa/ask-sdk-controls/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
