### PR TITLE
feat: introduce functionality to determine request input modality and…

### DIFF
--- a/demo/NumberControl/NumberDemo/test/numberDemo.spec.ts
+++ b/demo/NumberControl/NumberDemo/test/numberDemo.spec.ts
@@ -84,8 +84,11 @@ suite('Number Demo', () => {
             invoker,
             'U: __',
             TestInput.simpleUserEvent(['number', 40]),
-            'A: Ok. Value set to 40.',
+            'A: ', // No voice prompt for touch
         );
+
+        expect(requestHandler.getSerializableControlStates().number.value).equals(40);
+        expect(requestHandler.getSerializableControlStates().number.confirmed).equals(true);
     });
 
     test('Number Demo - screen input, invalid, new value valid', async () => {
@@ -97,8 +100,11 @@ suite('Number Demo', () => {
             invoker,
             'U: __',
             TestInput.simpleUserEvent(['number', 3]),
-            "A: Sorry but that's not a valid choice because the value must be even. What number?",
+            'A: ', // No voice prompt for touch
         );
+
+        expect(requestHandler.getSerializableControlStates().number.value).equals(3);
+        expect(requestHandler.getSerializableControlStates().number.confirmed).equals(false);
 
         await testTurn(
             invoker,

--- a/src/controls/ControlInput.ts
+++ b/src/controls/ControlInput.ts
@@ -16,6 +16,40 @@ import { Request } from 'ask-sdk-model';
 import _ from 'lodash';
 import { IControlInput } from './interfaces/IControlInput';
 import { IControl } from './interfaces/IControl';
+import { InputModality, ResponseStyle } from '../modality/ModalityEvaluation';
+
+/**
+ * Properties for creating a ControlInput instance.
+ */
+export interface ControlInputProps {
+    /**
+     * The core input for the request.
+     */
+    handlerInput: HandlerInput;
+
+    /**
+     * The turn number of the current request.
+     */
+    turnNumber: number;
+
+    /**
+     * A map of Control IDs to Controls for the current control tree.
+     */
+    controlMap: { [index: string]: IControl };
+
+    /**
+     * The style in which the skill is recommended to respond to the current request,
+     * e.g. with a screen or voice interface, based on how the user responded to
+     * previous requests.
+     */
+    suggestedResponseStyle: ResponseStyle;
+
+    /**
+     * The history of how the user responded to previous requests,
+     * e.g. with touch or voice.
+     */
+    inputModalityHistory: InputModality[];
+}
 
 /**
  * Defines an expanded input object passed around during processing by Controls.
@@ -43,6 +77,18 @@ export class ControlInput implements IControlInput {
     readonly turnNumber: number;
 
     /**
+     * The style in which the skill is recommended to respond to the request,
+     * e.g. with a screen or voice modality.
+     */
+    readonly suggestedResponseStyle: ResponseStyle;
+
+    /**
+     * The history of what modality the user responded with for each turn,
+     * e.g. voice or touch.
+     */
+    readonly inputModalityHistory: InputModality[];
+
+    /**
      * All the controls of the control tree, indexed by controlID.
      *
      * Usage:
@@ -55,10 +101,12 @@ export class ControlInput implements IControlInput {
      */
     readonly controls: { [index: string]: IControl };
 
-    constructor(handlerInput: HandlerInput, turnNumber: number, controlMap: { [index: string]: IControl }) {
-        this.handlerInput = handlerInput;
+    constructor(props: ControlInputProps) {
+        this.handlerInput = props.handlerInput;
         this.request = this.handlerInput.requestEnvelope.request;
-        this.turnNumber = turnNumber;
-        this.controls = controlMap;
+        this.turnNumber = props.turnNumber;
+        this.controls = props.controlMap;
+        this.suggestedResponseStyle = props.suggestedResponseStyle;
+        this.inputModalityHistory = props.inputModalityHistory;
     }
 }

--- a/src/controls/interfaces/IControlManager.ts
+++ b/src/controls/interfaces/IControlManager.ts
@@ -12,6 +12,7 @@
  */
 
 import { HandlerInput } from 'ask-sdk-core';
+import { InputModality, ResponseStyle } from '../../modality/ModalityEvaluation';
 import { ControlResponseBuilder } from '../../responseGeneration/ControlResponseBuilder';
 import { IControl } from './IControl';
 import { IControlInput } from './IControlInput';
@@ -88,4 +89,21 @@ export interface IControlManager {
      *
      */
     saveControlStateMap(state: any, handlerInput: HandlerInput): Promise<void>;
+
+    /**
+     * Determines the input modality of the current turn, based on the
+     * currently-configured evaluator function.
+     * @param handlerInput - Input for the current turn.
+     * @returns InputModality - Input modality determined for the current turn.
+     */
+    evaluateInputModality(handlerInput: HandlerInput): InputModality;
+
+    /**
+     * Determines the recommended response style for the current turn, based on the
+     * current-configured evaluator function.
+     * @param handlerInput - Input for the current turn.
+     * @param history - History of input modality of previous turns.
+     * @returns ResponseStyle - Recommended response style for the current turn.
+     */
+    evaluateResponseStyle(input: HandlerInput, history: InputModality[]): ResponseStyle;
 }

--- a/src/modality/ModalityEvaluation.ts
+++ b/src/modality/ModalityEvaluation.ts
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import { HandlerInput } from 'ask-sdk-core';
+
+/**
+ * Possible modalities a user can use to respond to a request.
+ */
+export enum InputModality {
+    /**
+     * User touched the screen.
+     */
+    TOUCH = 'touch',
+    /**
+     * User used their voice.
+     */
+    VOICE = 'voice',
+}
+
+/**
+ * Possible modalities with which the skill may respond to a request.
+ */
+export enum OutputModality {
+    /**
+     * Response is only displayed on the screen.
+     */
+    SCREEN = 'screen',
+
+    /**
+     * Response is in the form of a voice prompt,
+     * and may or may not include content displayed on the screen.
+     */
+    VOICE = 'voice',
+
+    /**
+     * Response type is not yet known.
+     */
+    INDETERMINATE = 'indeterminate',
+}
+
+/**
+ * Describes the style in which a request should be responded to.
+ * The most basic characteristic is what modality the response should have,
+ * but this interface may be extended to describe additional characteristics
+ * as desired (e.g. whispering).
+ */
+export interface ResponseStyle {
+    /**
+     * The modality with which a request should be responded to.
+     */
+    modality: OutputModality;
+}
+
+/**
+ * A function that determines the input modality of a request.
+ */
+export type InputModalityEvaluator = (input: HandlerInput) => InputModality;
+
+/**
+ * A function that suggests the style in which a request should be responded to,
+ * based on the content of the request and the history of how the user responded.
+ */
+export type ResponseStyleEvaluator = (input: HandlerInput, history: InputModality[]) => ResponseStyle;
+
+/**
+ * Default functions for determining input modality and response styles.
+ */
+export namespace ModalityEvaluationDefaults {
+    /**
+     * Default function for determining the input modality of a request.
+     * This is best-effort and may not work in all cases.
+     * @param input - Input for the current request
+     * @returns InputModality - TOUCH if the request came from a TouchWrapper,
+     * VOICE otherwise.
+     */
+    export function defaultInputModalityEvaluator(input: HandlerInput): InputModality {
+        const request = input.requestEnvelope.request;
+        if (request.type === 'Alexa.Presentation.APL.UserEvent') {
+            if (request.source?.type === 'TouchWrapper') {
+                return InputModality.TOUCH;
+            }
+        }
+        return InputModality.VOICE;
+    }
+
+    /**
+     * Default function for suggesting the style in which a request should be responded to.
+     * @param input - Input for the current request
+     * @param history - History of how the user responded to previous requests.
+     * The current request is the last entry.
+     * @returns ResponseStyle - SCREEN modality if the last InputModality was TOUCH, VOICE otherwise.
+     */
+    export function defaultResponseStyleEvaluator(
+        input: HandlerInput,
+        history: InputModality[],
+    ): ResponseStyle {
+        if (history?.length > 0 && history[history.length - 1] === InputModality.TOUCH) {
+            return { modality: OutputModality.SCREEN };
+        }
+
+        return { modality: OutputModality.VOICE };
+    }
+
+    /**
+     * Function that always returns an INDETERMINATE modality for a suggested ResponseStyle.
+     * This is primarily used as the default override function for built-in controls, which results
+     * in the controls deferring the decision to the function at the ControlManager level.
+     * @returns OutputModality.INDETERMINATE
+     */
+    export function indeterminateResponseStyleEvaluator(input: HandlerInput, history: InputModality[]) {
+        return { modality: OutputModality.INDETERMINATE };
+    }
+}

--- a/src/systemActs/ContentActs.ts
+++ b/src/systemActs/ContentActs.ts
@@ -15,6 +15,7 @@ import i18next from 'i18next';
 import { Control } from '../controls/Control';
 import { ControlInput } from '../controls/ControlInput';
 import { ControlResponseBuilder } from '../responseGeneration/ControlResponseBuilder';
+import { addFragmentsForResponseStyle } from '../utils/ResponseUtils';
 import {
     InvalidValuePayload,
     LiteralContentPayload,
@@ -70,11 +71,13 @@ export class UnusableInputValueAct<T> extends ContentAct {
 
     render(input: ControlInput, controlResponseBuilder: ControlResponseBuilder): void {
         if (this.payload.renderedReason !== undefined) {
-            controlResponseBuilder.addPromptFragment(
-                i18next.t('UNUSABLE_INPUT_VALUE_ACT_DEFAULT_PROMPT', {
+            addFragmentsForResponseStyle({
+                responseStyle: input.suggestedResponseStyle,
+                voicePrompt: i18next.t('UNUSABLE_INPUT_VALUE_ACT_DEFAULT_PROMPT', {
                     value: this.payload.renderedReason,
                 }),
-            );
+                builder: controlResponseBuilder,
+            });
         } else {
             throw new Error(
                 `Cannot directly render UnusableInputValueAct as payload.renderedReason is undefined. ${this.toString()}. ` +
@@ -101,7 +104,11 @@ export class AcknowledgeInputAct extends ContentAct {
     }
 
     render(input: ControlInput, controlResponseBuilder: ControlResponseBuilder): void {
-        controlResponseBuilder.addPromptFragment(i18next.t('ACKNOWLEDGE_INPUT_ACT_DEFAULT_PROMPT'));
+        addFragmentsForResponseStyle({
+            responseStyle: input.suggestedResponseStyle,
+            voicePrompt: i18next.t('ACKNOWLEDGE_INPUT_ACT_DEFAULT_PROMPT'),
+            builder: controlResponseBuilder,
+        });
     }
 }
 
@@ -134,11 +141,13 @@ export class ValueSetAct<T> extends ContentAct {
     }
 
     render(input: ControlInput, controlResponseBuilder: ControlResponseBuilder): void {
-        controlResponseBuilder.addPromptFragment(
-            i18next.t('VALUE_SET_ACT_DEFAULT_PROMPT', {
+        addFragmentsForResponseStyle({
+            responseStyle: input.suggestedResponseStyle,
+            voicePrompt: i18next.t('VALUE_SET_ACT_DEFAULT_PROMPT', {
                 value: this.payload.value,
             }),
-        );
+            builder: controlResponseBuilder,
+        });
     }
 }
 
@@ -168,11 +177,13 @@ export class ValueChangedAct<T> extends ContentAct {
     }
 
     render(input: ControlInput, controlResponseBuilder: ControlResponseBuilder): void {
-        controlResponseBuilder.addPromptFragment(
-            i18next.t('VALUE_CHANGED_ACT_DEFAULT_PROMPT', {
+        addFragmentsForResponseStyle({
+            responseStyle: input.suggestedResponseStyle,
+            voicePrompt: i18next.t('VALUE_CHANGED_ACT_DEFAULT_PROMPT', {
                 value: this.payload.value,
             }),
-        );
+            builder: controlResponseBuilder,
+        });
     }
 }
 
@@ -200,11 +211,13 @@ export class InvalidValueAct<T> extends ContentAct {
 
     render(input: ControlInput, controlResponseBuilder: ControlResponseBuilder): void {
         if (this.payload.renderedReason !== undefined) {
-            controlResponseBuilder.addPromptFragment(
-                i18next.t('INVALID_VALUE_ACT_DEFAULT_PROMPT', {
+            addFragmentsForResponseStyle({
+                responseStyle: input.suggestedResponseStyle,
+                voicePrompt: i18next.t('INVALID_VALUE_ACT_DEFAULT_PROMPT', {
                     value: this.payload.renderedReason,
                 }),
-            );
+                builder: controlResponseBuilder,
+            });
         } else {
             throw new Error(
                 `Cannot directly render InvalidValueAct as payload.renderedReason is undefined. ${this.toString()}. ` +
@@ -238,7 +251,11 @@ export class ValueConfirmedAct<T> extends ContentAct {
     }
 
     render(input: ControlInput, controlResponseBuilder: ControlResponseBuilder): void {
-        controlResponseBuilder.addPromptFragment(i18next.t('VALUE_CONFIRMED_ACT_DEFAULT_PROMPT'));
+        addFragmentsForResponseStyle({
+            responseStyle: input.suggestedResponseStyle,
+            voicePrompt: i18next.t('VALUE_CONFIRMED_ACT_DEFAULT_PROMPT'),
+            builder: controlResponseBuilder,
+        });
     }
 }
 
@@ -266,7 +283,11 @@ export class ValueDisconfirmedAct<T> extends ContentAct {
     }
 
     render(input: ControlInput, controlResponseBuilder: ControlResponseBuilder): void {
-        controlResponseBuilder.addPromptFragment(i18next.t('VALUE_DISCONFIRMED_ACT_DEFAULT_PROMPT'));
+        addFragmentsForResponseStyle({
+            responseStyle: input.suggestedResponseStyle,
+            voicePrompt: i18next.t('VALUE_DISCONFIRMED_ACT_DEFAULT_PROMPT'),
+            builder: controlResponseBuilder,
+        });
     }
 }
 
@@ -294,7 +315,11 @@ export class NonUnderstandingAct extends ContentAct {
     }
 
     render(input: ControlInput, controlResponseBuilder: ControlResponseBuilder): void {
-        controlResponseBuilder.addPromptFragment(i18next.t('NON_UNDERSTANDING_ACT_DEFAULT_PROMPT'));
+        addFragmentsForResponseStyle({
+            responseStyle: input.suggestedResponseStyle,
+            voicePrompt: i18next.t('NON_UNDERSTANDING_ACT_DEFAULT_PROMPT'),
+            builder: controlResponseBuilder,
+        });
     }
 }
 
@@ -309,7 +334,11 @@ export class LaunchAct extends ContentAct {
     }
 
     render(input: ControlInput, controlResponseBuilder: ControlResponseBuilder): void {
-        controlResponseBuilder.addPromptFragment(i18next.t('LAUNCH_ACT_DEFAULT_PROMPT'));
+        addFragmentsForResponseStyle({
+            responseStyle: input.suggestedResponseStyle,
+            voicePrompt: i18next.t('LAUNCH_ACT_DEFAULT_PROMPT'),
+            builder: controlResponseBuilder,
+        });
     }
 }
 
@@ -338,8 +367,12 @@ export class LiteralContentAct extends ContentAct {
     }
 
     render(input: ControlInput, controlResponseBuilder: ControlResponseBuilder): void {
-        controlResponseBuilder.addPromptFragment(this.payload.promptFragment);
-        controlResponseBuilder.addRepromptFragment(this.payload.repromptFragment!);
+        addFragmentsForResponseStyle({
+            responseStyle: input.suggestedResponseStyle,
+            voicePrompt: this.payload.promptFragment,
+            voiceReprompt: this.payload.repromptFragment!,
+            builder: controlResponseBuilder,
+        });
     }
 }
 
@@ -352,11 +385,13 @@ export class ValueAddedAct<T> extends ContentAct {
     }
 
     render(input: ControlInput, controlResponseBuilder: ControlResponseBuilder): void {
-        controlResponseBuilder.addPromptFragment(
-            i18next.t('VALUE_ADDED_ACT_DEFAULT_PROMPT', {
+        addFragmentsForResponseStyle({
+            responseStyle: input.suggestedResponseStyle,
+            voicePrompt: i18next.t('VALUE_ADDED_ACT_DEFAULT_PROMPT', {
                 value: this.payload.value,
             }),
-        );
+            builder: controlResponseBuilder,
+        });
     }
 }
 
@@ -369,11 +404,13 @@ export class ValueRemovedAct<T> extends ContentAct {
     }
 
     render(input: ControlInput, controlResponseBuilder: ControlResponseBuilder): void {
-        controlResponseBuilder.addPromptFragment(
-            i18next.t('VALUE_REMOVED_ACT_DEFAULT_PROMPT', {
+        addFragmentsForResponseStyle({
+            responseStyle: input.suggestedResponseStyle,
+            voicePrompt: i18next.t('VALUE_REMOVED_ACT_DEFAULT_PROMPT', {
                 value: this.payload.value,
             }),
-        );
+            builder: controlResponseBuilder,
+        });
     }
 }
 
@@ -386,11 +423,13 @@ export class ValueClearedAct<T> extends ContentAct {
     }
 
     render(input: ControlInput, controlResponseBuilder: ControlResponseBuilder): void {
-        controlResponseBuilder.addPromptFragment(
-            i18next.t('VALUE_CLEARED_ACT_DEFAULT_PROMPT', {
+        addFragmentsForResponseStyle({
+            responseStyle: input.suggestedResponseStyle,
+            voicePrompt: i18next.t('VALUE_CLEARED_ACT_DEFAULT_PROMPT', {
                 value: this.payload.value,
             }),
-        );
+            builder: controlResponseBuilder,
+        });
     }
 }
 
@@ -403,10 +442,12 @@ export class InvalidRemoveValueAct<T> extends ContentAct {
     }
 
     render(input: ControlInput, controlResponseBuilder: ControlResponseBuilder): void {
-        controlResponseBuilder.addPromptFragment(
-            i18next.t('INVALID_REMOVE_VALUE_ACT_DEFAULT_PROMPT', {
+        addFragmentsForResponseStyle({
+            responseStyle: input.suggestedResponseStyle,
+            voicePrompt: i18next.t('INVALID_REMOVE_VALUE_ACT_DEFAULT_PROMPT', {
                 value: this.payload.value,
             }),
-        );
+            builder: controlResponseBuilder,
+        });
     }
 }

--- a/src/systemActs/InitiativeActs.ts
+++ b/src/systemActs/InitiativeActs.ts
@@ -16,6 +16,7 @@ import { Control } from '../controls/Control';
 import { ControlInput } from '../controls/ControlInput';
 import { ListFormatting } from '../intl/ListFormat';
 import { ControlResponseBuilder } from '../responseGeneration/ControlResponseBuilder';
+import { addFragmentsForResponseStyle } from '../utils/ResponseUtils';
 import {
     LiteralContentPayload,
     RequestChangedValueByListPayload,
@@ -95,16 +96,16 @@ export class RequestValueAct extends InitiativeAct {
     }
     render(input: ControlInput, controlResponseBuilder: ControlResponseBuilder): void {
         if (this.payload.renderedTarget !== undefined) {
-            controlResponseBuilder.addPromptFragment(
-                i18next.t('REQUEST_VALUE_ACT_DEFAULT_PROMPT', {
+            addFragmentsForResponseStyle({
+                responseStyle: input.suggestedResponseStyle,
+                voicePrompt: i18next.t('REQUEST_VALUE_ACT_DEFAULT_PROMPT', {
                     value: this.payload.renderedTarget,
                 }),
-            );
-            controlResponseBuilder.addRepromptFragment(
-                i18next.t('REQUEST_VALUE_ACT_DEFAULT_PROMPT', {
+                voiceReprompt: i18next.t('REQUEST_VALUE_ACT_DEFAULT_PROMPT', {
                     value: this.payload.renderedTarget,
                 }),
-            );
+                builder: controlResponseBuilder,
+            });
         } else {
             throw new Error(
                 `Cannot directly render RequestValueAct as payload.renderedTarget is undefined. ${this.toString()}. ` +
@@ -133,16 +134,16 @@ export class RequestChangedValueAct extends InitiativeAct {
     }
     render(input: ControlInput, controlResponseBuilder: ControlResponseBuilder): void {
         if (this.payload.renderedTarget !== undefined) {
-            controlResponseBuilder.addPromptFragment(
-                i18next.t('REQUEST_CHANGED_VALUE_ACT_DEFAULT_PROMPT', {
+            addFragmentsForResponseStyle({
+                responseStyle: input.suggestedResponseStyle,
+                voicePrompt: i18next.t('REQUEST_CHANGED_VALUE_ACT_DEFAULT_PROMPT', {
                     value: this.payload.renderedTarget,
                 }),
-            );
-            controlResponseBuilder.addRepromptFragment(
-                i18next.t('REQUEST_CHANGED_VALUE_ACT_DEFAULT_PROMPT', {
+                voiceReprompt: i18next.t('REQUEST_CHANGED_VALUE_ACT_DEFAULT_PROMPT', {
                     value: this.payload.renderedTarget,
                 }),
-            );
+                builder: controlResponseBuilder,
+            });
         } else {
             throw new Error(
                 `Cannot directly render RequestChangedValueAct as payload.renderedTarget is undefined. ${this.toString()}. ` +
@@ -172,18 +173,18 @@ export class RequestValueByListAct extends InitiativeAct {
     }
     render(input: ControlInput, controlResponseBuilder: ControlResponseBuilder): void {
         if (this.payload.renderedTarget !== undefined && this.payload.renderedChoices !== undefined) {
-            controlResponseBuilder.addPromptFragment(
-                i18next.t('REQUEST_VALUE_BY_LIST_ACT_DEFAULT_PROMPT', {
+            addFragmentsForResponseStyle({
+                responseStyle: input.suggestedResponseStyle,
+                voicePrompt: i18next.t('REQUEST_VALUE_BY_LIST_ACT_DEFAULT_PROMPT', {
                     value: this.payload.renderedTarget,
                     choices: this.payload.renderedChoices,
                 }),
-            );
-            controlResponseBuilder.addRepromptFragment(
-                i18next.t('REQUEST_VALUE_BY_LIST_ACT_DEFAULT_PROMPT', {
+                voiceReprompt: i18next.t('REQUEST_VALUE_BY_LIST_ACT_DEFAULT_PROMPT', {
                     value: this.payload.renderedTarget,
                     choices: this.payload.renderedChoices,
                 }),
-            );
+                builder: controlResponseBuilder,
+            });
         } else {
             throw new Error(
                 `Cannot directly render RequestValueByListAct as payload.renderedTarget is undefined. ${this.toString()}. ` +
@@ -213,18 +214,18 @@ export class RequestChangedValueByListAct extends InitiativeAct {
     }
     render(input: ControlInput, controlResponseBuilder: ControlResponseBuilder): void {
         if (this.payload.renderedTarget !== undefined) {
-            controlResponseBuilder.addPromptFragment(
-                i18next.t('REQUEST_CHANGED_VALUE_BY_LIST_ACT_DEFAULT_PROMPT', {
+            addFragmentsForResponseStyle({
+                responseStyle: input.suggestedResponseStyle,
+                voicePrompt: i18next.t('REQUEST_CHANGED_VALUE_BY_LIST_ACT_DEFAULT_PROMPT', {
                     value: this.payload.renderedTarget,
                     choices: ListFormatting.format(this.payload.choicesFromActivePage),
                 }),
-            );
-            controlResponseBuilder.addRepromptFragment(
-                i18next.t('REQUEST_CHANGED_VALUE_BY_LIST_ACT_DEFAULT_PROMPT', {
+                voiceReprompt: i18next.t('REQUEST_CHANGED_VALUE_BY_LIST_ACT_DEFAULT_PROMPT', {
                     value: this.payload.renderedTarget,
                     choices: ListFormatting.format(this.payload.choicesFromActivePage),
                 }),
-            );
+                builder: controlResponseBuilder,
+            });
         } else {
             throw new Error(
                 `Cannot directly render RequestChangedValueByListAct as payload.renderedTarget is undefined. ${this.toString()}. ` +
@@ -243,18 +244,18 @@ export class RequestRemovedValueByListAct extends InitiativeAct {
     }
     render(input: ControlInput, controlResponseBuilder: ControlResponseBuilder): void {
         if (this.payload.renderedTarget !== undefined && this.payload.renderedChoices !== undefined) {
-            controlResponseBuilder.addPromptFragment(
-                i18next.t('REQUEST_REMOVED_VALUE_BY_LIST_ACT_DEFAULT_PROMPT', {
+            addFragmentsForResponseStyle({
+                responseStyle: input.suggestedResponseStyle,
+                voicePrompt: i18next.t('REQUEST_REMOVED_VALUE_BY_LIST_ACT_DEFAULT_PROMPT', {
                     value: this.payload.renderedTarget,
                     choices: this.payload.renderedChoices,
                 }),
-            );
-            controlResponseBuilder.addRepromptFragment(
-                i18next.t('REQUEST_REMOVED_VALUE_BY_LIST_ACT_DEFAULT_PROMPT', {
+                voiceReprompt: i18next.t('REQUEST_REMOVED_VALUE_BY_LIST_ACT_DEFAULT_PROMPT', {
                     value: this.payload.renderedTarget,
                     choices: this.payload.renderedChoices,
                 }),
-            );
+                builder: controlResponseBuilder,
+            });
         } else {
             throw new Error(
                 `Cannot directly render RequestRemovedValueByListAct as payload.renderedTarget is undefined. ${this.toString()}. ` +
@@ -277,16 +278,16 @@ export class ConfirmValueAct<T> extends InitiativeAct {
         this.payload = payload;
     }
     render(input: ControlInput, controlResponseBuilder: ControlResponseBuilder): void {
-        controlResponseBuilder.addPromptFragment(
-            i18next.t('CONFIRM_VALUE_ACT_DEFAULT_PROMPT', {
+        addFragmentsForResponseStyle({
+            responseStyle: input.suggestedResponseStyle,
+            voicePrompt: i18next.t('CONFIRM_VALUE_ACT_DEFAULT_PROMPT', {
                 value: this.payload.value,
             }),
-        );
-        controlResponseBuilder.addRepromptFragment(
-            i18next.t('CONFIRM_VALUE_ACT_DEFAULT_PROMPT', {
+            voiceReprompt: i18next.t('CONFIRM_VALUE_ACT_DEFAULT_PROMPT', {
                 value: this.payload.value,
             }),
-        );
+            builder: controlResponseBuilder,
+        });
     }
 }
 
@@ -312,8 +313,12 @@ export class LiteralInitiativeAct extends InitiativeAct {
         };
     }
     render(input: ControlInput, controlResponseBuilder: ControlResponseBuilder): void {
-        controlResponseBuilder.addPromptFragment(this.payload.promptFragment);
-        controlResponseBuilder.addRepromptFragment(this.payload.repromptFragment!);
+        addFragmentsForResponseStyle({
+            responseStyle: input.suggestedResponseStyle,
+            voicePrompt: this.payload.promptFragment,
+            voiceReprompt: this.payload.repromptFragment!,
+            builder: controlResponseBuilder,
+        });
     }
 }
 
@@ -330,16 +335,16 @@ export class SuggestValueAct<T> extends InitiativeAct {
         this.payload = payload;
     }
     render(input: ControlInput, controlResponseBuilder: ControlResponseBuilder): void {
-        controlResponseBuilder.addPromptFragment(
-            i18next.t('SUGGEST_VALUE_ACT_DEFAULT_PROMPT', {
+        addFragmentsForResponseStyle({
+            responseStyle: input.suggestedResponseStyle,
+            voicePrompt: i18next.t('SUGGEST_VALUE_ACT_DEFAULT_PROMPT', {
                 value: this.payload.value,
             }),
-        );
-        controlResponseBuilder.addRepromptFragment(
-            i18next.t('SUGGEST_VALUE_ACT_DEFAULT_PROMPT', {
+            voiceReprompt: i18next.t('SUGGEST_VALUE_ACT_DEFAULT_PROMPT', {
                 value: this.payload.value,
             }),
-        );
+            builder: controlResponseBuilder,
+        });
     }
 }
 
@@ -352,8 +357,12 @@ export class SuggestActionAct<T> extends InitiativeAct {
     }
     render(input: ControlInput, controlResponseBuilder: ControlResponseBuilder): void {
         if (this.payload.renderedTarget !== undefined) {
-            controlResponseBuilder.addPromptFragment(i18next.t('SUGGEST_ACTION_ACT_DEFAULT_PROMPT'));
-            controlResponseBuilder.addRepromptFragment(i18next.t('SUGGEST_ACTION_ACT_DEFAULT_PROMPT'));
+            addFragmentsForResponseStyle({
+                responseStyle: input.suggestedResponseStyle,
+                voicePrompt: i18next.t('SUGGEST_ACTION_ACT_DEFAULT_PROMPT'),
+                voiceReprompt: i18next.t('SUGGEST_ACTION_ACT_DEFAULT_PROMPT'),
+                builder: controlResponseBuilder,
+            });
         } else {
             throw new Error(
                 `Cannot directly render SuggestActionAct as payload.renderedTarget is undefined. ${this.toString()}. ` +

--- a/src/utils/ResponseUtils.ts
+++ b/src/utils/ResponseUtils.ts
@@ -16,6 +16,9 @@ import { ControlResponseBuilder } from '../responseGeneration/ControlResponseBui
 import { Response } from 'ask-sdk-model';
 import { ControlInput } from '../controls/ControlInput';
 
+/**
+ * Properties for building a response based on ResponseStyle.
+ */
 export interface ResponseStyleBuilderProps {
     voicePrompt: string;
     voiceReprompt?: string;
@@ -23,7 +26,17 @@ export interface ResponseStyleBuilderProps {
     builder: ControlResponseBuilder;
 }
 
-export function addFragmentsForResponseStyle(props: ResponseStyleBuilderProps) {
+/**
+ * Adds voice prompt and reprompt to a ControlResponseBuilder conditionally based on
+ * the ResponseStyle contained in the ResponseStyleBuilderProps.
+ * 
+ * If the modality of the response style is SCREEN, the voice prompt and reprompt
+ * will not be added. In any other case, they will be added.
+ * 
+ * @param props ResponseStyleBuilderProps - properties needed for adding prompts to
+ * the response.
+ */
+export function addFragmentsForResponseStyle(props: ResponseStyleBuilderProps): void {
     const voicePrompt = props.voicePrompt;
     const voiceReprompt = props.voiceReprompt;
     const responseStyle = props.responseStyle;
@@ -40,12 +53,33 @@ export function addFragmentsForResponseStyle(props: ResponseStyleBuilderProps) {
     }
 }
 
+/**
+ * Adds voice prompt and reprompt to a ControlResponseBuilder conditionally based on
+ * the ResponseStyle contained in the ResponseStyleBuilderProps.
+ * 
+ * If the modality of the response style is SCREEN, the voice prompt and reprompt
+ * will not be added. In any other case, they will be added.
+ * 
+ * After adding the prompts, the response is built.
+ * 
+ * @param props ResponseStyleBuilderProps - properties needed for adding prompts to
+ * the response.
+ * @returns Response - The response for the current skill turn.
+ */
 export function buildResponseForStyle(props: ResponseStyleBuilderProps): Response {
     addFragmentsForResponseStyle(props);
 
     return props.builder.build();
 }
 
+/**
+ * Executes a ResponseStyleEvaluator override function and determines whether to use
+ * the result from it or the base, non-overridden result.
+ * @param evaluator ResponseStyleEvaluator - Overridden ResponseStyleEvaluator
+ * @param input ControlInput - Input for the current skill turn
+ * @returns ResponseStyle - Uses the result from the provided evaluator if it was
+ * determinate, otherwise uses the ResponseStyle present in the provided ControlInput.
+ */
 export function getDeterminateResponseStyle(
     evaluator: ResponseStyleEvaluator,
     input: ControlInput,

--- a/src/utils/ResponseUtils.ts
+++ b/src/utils/ResponseUtils.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import { OutputModality, ResponseStyle, ResponseStyleEvaluator } from '../modality/ModalityEvaluation';
+import { ControlResponseBuilder } from '../responseGeneration/ControlResponseBuilder';
+import { Response } from 'ask-sdk-model';
+import { ControlInput } from '../controls/ControlInput';
+
+export interface ResponseStyleBuilderProps {
+    voicePrompt: string;
+    voiceReprompt?: string;
+    responseStyle: ResponseStyle;
+    builder: ControlResponseBuilder;
+}
+
+export function addFragmentsForResponseStyle(props: ResponseStyleBuilderProps) {
+    const voicePrompt = props.voicePrompt;
+    const voiceReprompt = props.voiceReprompt;
+    const responseStyle = props.responseStyle;
+
+    const builder = props.builder;
+    if (responseStyle.modality === OutputModality.SCREEN) {
+        return;
+    }
+
+    builder.addPromptFragment(voicePrompt);
+
+    if (voiceReprompt !== undefined) {
+        builder.addRepromptFragment(voiceReprompt);
+    }
+}
+
+export function buildResponseForStyle(props: ResponseStyleBuilderProps): Response {
+    addFragmentsForResponseStyle(props);
+
+    return props.builder.build();
+}
+
+export function getDeterminateResponseStyle(
+    evaluator: ResponseStyleEvaluator,
+    input: ControlInput,
+): ResponseStyle {
+    const overriddenResponseStyle = evaluator(input.handlerInput, input.inputModalityHistory);
+
+    if (overriddenResponseStyle.modality !== OutputModality.INDETERMINATE) {
+        return overriddenResponseStyle;
+    }
+
+    return input.suggestedResponseStyle;
+}

--- a/src/utils/testSupport/TestingUtils.ts
+++ b/src/utils/testSupport/TestingUtils.ts
@@ -29,6 +29,7 @@ import { ControlServices, ControlServicesProps } from '../../controls/ControlSer
 import { IControl } from '../../controls/interfaces/IControl';
 import { IControlInput } from '../../controls/interfaces/IControlInput';
 import { IControlResult } from '../../controls/interfaces/IControlResult';
+import { InputModality, OutputModality } from '../../modality/ModalityEvaluation';
 import { ControlHandler } from '../../runtime/ControlHandler';
 import { IntentBuilder } from '../IntentUtils';
 import { SkillInvoker, TestResponseObject } from './SkillInvoker';
@@ -180,6 +181,7 @@ export async function testTurn(
     expectedResponse: string | string[] | TestResponseObject,
 ): Promise<TestResponseObject> {
     const testResponse = await invoker.invoke(input);
+
     if (Array.isArray(expectedResponse)) {
         expect(_.includes(expectedResponse, testResponse.prompt)).equals(true);
     } else {
@@ -214,6 +216,8 @@ export async function testTurn(
  */
 export class TestInput {
     static turnNumber = 1;
+    static responseStyle = { modality: OutputModality.VOICE };
+    static inputModality = InputModality.VOICE;
 
     /**
      * Reset the turn counter.
@@ -401,6 +405,8 @@ function dummyControlInput(request?: Request): ControlInput {
         request: handlerInput.requestEnvelope.request,
         turnNumber: TestInput.turnNumber,
         controls: {},
+        suggestedResponseStyle: TestInput.responseStyle,
+        inputModalityHistory: [TestInput.inputModality],
     };
 }
 const dummyAttributesManager: AttributesManager = AttributesManagerFactory.init({

--- a/test/commonControlTests/ListControl.spec.ts
+++ b/test/commonControlTests/ListControl.spec.ts
@@ -11,6 +11,7 @@
  * permissions and limitations under the License.
  */
 
+import { expect } from 'chai';
 import { suite, test } from 'mocha';
 import { GeneralControlIntent } from '../../src';
 import { ListControl } from '../../src/commonControls/listControl/ListControl';
@@ -142,6 +143,21 @@ suite('ListControl e2e tests', () => {
             TestInput.of(IntentBuilder.of(AmazonIntent.YesIntent)),
             'A: Great.',
         );
+    });
+
+    test('Select by touch', async () => {
+        const requestHandler = new ControlHandler(new ListControlManager());
+        const invoker = new SkillInvoker(requestHandler);
+
+        await testTurn(
+            invoker,
+            'U: <touches "MacBook">',
+            TestInput.simpleUserEvent(['apple', 3]),
+            'A: ', // No voice prompt for touch
+        );
+
+        expect(requestHandler.getSerializableControlStates().apple.value).equals('MacBook');
+        expect(requestHandler.getSerializableControlStates().apple.erMatch).equals(true);
     });
 
     //--

--- a/test/commonControlTests/MultiValueListControl.spec.ts
+++ b/test/commonControlTests/MultiValueListControl.spec.ts
@@ -231,18 +231,23 @@ suite('MultiValueListControl e2e tests', () => {
         test('Select by touch', async () => {
             const requestHandler = new ControlHandler(new CategorySuiteManager());
             const invoker = new SkillInvoker(requestHandler);
+
             await testTurn(
                 invoker,
-                'U: _',
+                'U: <touches "AirPods">',
                 TestInput.simpleUserEvent(['apple', 'Select', 1]),
-                'A: OK, added AirPods. Is that all?',
+                'A: ', // No voice prompt for touch
             );
+
+            expect(requestHandler.getSerializableControlStates().apple.value).deep.equals([
+                { id: 'AirPods', erMatch: true },
+            ]);
 
             const response = await testTurn(
                 invoker,
-                'U: _',
+                'U: <touches "iPhone">',
                 TestInput.simpleUserEvent(['apple', 'Select', 3]),
-                'A: OK, added iPhone. Is that all?',
+                'A: ', // No voice prompt for touch
             );
 
             expect(response.directive !== undefined); // APL re-renders with updated selected list
@@ -254,9 +259,9 @@ suite('MultiValueListControl e2e tests', () => {
 
             await testTurn(
                 invoker,
-                'U: _',
+                'U: <removes "AirPods">',
                 TestInput.simpleUserEvent(['apple', 'Remove', 1]),
-                'A: OK, removed AirPods. Is that all?',
+                'A: ', // No voice prompt for touch
             );
 
             expect(requestHandler.getSerializableControlStates().apple.value).deep.equals([

--- a/test/modality.spec.ts
+++ b/test/modality.spec.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import { suite, test } from 'mocha';
+import { expect } from 'chai';
+import {
+    InputModality,
+    ModalityEvaluationDefaults,
+    OutputModality,
+    ResponseStyle,
+} from '../src/modality/ModalityEvaluation';
+import { HandlerInput } from 'ask-sdk-core';
+import { TestInput } from '../src/utils/testSupport/TestingUtils';
+import { ControlHandler } from '../src/runtime/ControlHandler';
+import { SkillInvoker } from '../src/utils/testSupport/SkillInvoker';
+import { ControlManager, ControlManagerProps } from '../src/controls/ControlManager';
+import { ControlInput } from '../src/controls/ControlInput';
+import { ContainerControl } from '../src/controls/ContainerControl';
+import { ControlResultBuilder } from '../src/controls/ControlResult';
+
+suite('== Modality evaluation and tracking scenarios ==', () => {
+    const touchInput = TestInput.simpleUserEvent([]);
+    const voiceInput = TestInput.of('VoiceIntent');
+    let manager: TestControlManager;
+    let handler: ControlHandler;
+    let rootControl: TestControl;
+    let lastHistory: InputModality[] | undefined;
+    let invoker: SkillInvoker;
+
+    beforeEach(() => {
+        manager = new TestControlManager({
+            responseStyleEvaluator,
+        });
+        handler = new ControlHandler(manager);
+        rootControl = manager.createControlTree();
+        rootControl.lastKnownModality = undefined;
+        lastHistory = undefined;
+        invoker = new SkillInvoker(handler);
+    });
+
+    test('Input and output modality are properly evaluated', async () => {
+        await invoker.invoke(touchInput);
+        expect(await rootControl.lastKnownModality).to.equal(OutputModality.SCREEN);
+
+        await invoker.invoke(voiceInput);
+        expect(await rootControl.lastKnownModality).to.equal(OutputModality.VOICE);
+    });
+
+    test('Input modality history is properly tracked', async () => {
+        await invoker.invoke(touchInput);
+        await invoker.invoke(voiceInput);
+        expect(lastHistory).to.deep.equal(['touch', 'voice']);
+    });
+
+    function responseStyleEvaluator(input: HandlerInput, history: InputModality[]): ResponseStyle {
+        lastHistory = JSON.parse(JSON.stringify(history));
+        return ModalityEvaluationDefaults.defaultResponseStyleEvaluator(input, history);
+    }
+});
+
+class TestControlManager extends ControlManager {
+    constructor(props?: ControlManagerProps) {
+        super(props);
+    }
+
+    createControlTree(state?: any, input?: ControlInput): TestControl {
+        return TestControl.getInstance();
+    }
+}
+
+class TestControl extends ContainerControl {
+    private static instance = new TestControl();
+
+    lastKnownModality: OutputModality | undefined = undefined;
+
+    private constructor() {
+        super({ id: 'TestControl' });
+    }
+
+    async canHandle(input: ControlInput): Promise<boolean> {
+        this.lastKnownModality = input.suggestedResponseStyle.modality;
+        return true;
+    }
+
+    async handle(input: ControlInput, resultBuilder: ControlResultBuilder): Promise<void> {
+        // Do nothing
+    }
+
+    static getInstance() {
+        return this.instance;
+    }
+}

--- a/test/scenarios.spec.ts
+++ b/test/scenarios.spec.ts
@@ -446,9 +446,8 @@ suite('== Custom List APL Props ==', () => {
         const dataSource = (response as any).directive[0].datasources;
 
         expect(response.directive?.length).eq(1);
-        expect(response.prompt).eq(
-            'Sorry, Wizard House: Muggle is not a valid choice because houseControl validation Failed. What is your selection? Some suggestions are Wizard House: Gryffindor, Wizard House: Ravenclaw or Wizard House: Slytherin.',
-        );
+        expect(requestHandler.getSerializableControlStates().hogwarts.value).equals('Muggle');
+        expect(requestHandler.getSerializableControlStates().hogwarts.isValueConfirmed).equals(false);
         expect(dataSource).deep.equals(expectedDataSource);
     });
 });

--- a/test/utilsTest/ResponseUtils.spec.ts
+++ b/test/utilsTest/ResponseUtils.spec.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import { ResponseFactory } from 'ask-sdk-core';
+import { Response, ui } from 'ask-sdk-model';
+import { expect } from 'chai';
+import { suite, test } from 'mocha';
+import { OutputModality } from '../../src/modality/ModalityEvaluation';
+import { ControlResponseBuilder } from '../../src/responseGeneration/ControlResponseBuilder';
+import { buildResponseForStyle } from '../../src/utils/ResponseUtils';
+
+suite('== ResponseUtils.buildResponseForStyle ==', () => {
+    let builder: ControlResponseBuilder;
+    const voicePrompt = 'voicePrompt';
+    const voiceReprompt = 'voiceReprompt';
+
+    beforeEach(() => {
+        builder = new ControlResponseBuilder(ResponseFactory.init());
+    });
+
+    test('Voice prompts and reprompts are ignored for screen modality', async () => {
+        const { voicePromptResponse, voiceRepromptResponse } = getSsmlFromResponse(
+            buildResponseForStyle({
+                voicePrompt,
+                voiceReprompt,
+                responseStyle: { modality: OutputModality.SCREEN },
+                builder,
+            }),
+        );
+
+        expect(voicePromptResponse).equal(getSsmlString());
+        expect(voiceRepromptResponse).equal(getSsmlString());
+    });
+
+    test('Voice prompts are included for voice modality', async () => {
+        const { voicePromptResponse, voiceRepromptResponse } = getSsmlFromResponse(
+            buildResponseForStyle({
+                voicePrompt,
+                responseStyle: { modality: OutputModality.VOICE },
+                builder,
+            }),
+        );
+
+        expect(voicePromptResponse).equal(getSsmlString(voicePrompt));
+        expect(voiceRepromptResponse).equal(getSsmlString());
+    });
+
+    test('Voice reprompts are included for voice modality', async () => {
+        const { voicePromptResponse, voiceRepromptResponse } = getSsmlFromResponse(
+            buildResponseForStyle({
+                voicePrompt,
+                voiceReprompt,
+                responseStyle: { modality: OutputModality.VOICE },
+                builder,
+            }),
+        );
+
+        expect(voicePromptResponse).equal(getSsmlString(voicePrompt));
+        expect(voiceRepromptResponse).equal(getSsmlString(voiceReprompt));
+    });
+
+    function getSsmlString(prompt?: string) {
+        return `<speak>${prompt ?? ''}</speak>`;
+    }
+
+    function getSsmlFromResponse(response: Response) {
+        return {
+            voicePromptResponse: (response.outputSpeech as ui.SsmlOutputSpeech).ssml,
+            voiceRepromptResponse: (response.reprompt?.outputSpeech as ui.SsmlOutputSpeech)?.ssml,
+        };
+    }
+});


### PR DESCRIPTION
… preferred response style. Adds utility to add appropriate prompts based on preferred response style. Modifies Act render methods and Control renderAct methods to use this utility

BREAKING CHANGE: Default Act rendering will no longer include voice prompts if the request input modality is from a touch event.

<!--- Provide a general summary of your changes in the Title above -->

## Description
This change does the following:
- Introduces the concept of request input modality: How the user responded to a request, e.g. using touch or voice.
- Introduces the concept of preferred response style: How Alexa should respond to the request, e.g. by displaying content on the screen only, or by using screen & voice.
- Introduces function types for determining the input modality of a request and the preferred response style.
- Introduces a best-effort default function for determining the input modality, which determines it to be touch if the request came from a TouchWrapper UserInput, or voice in any other case.
- Introduces a default function for determining the preferred response style, which determines it to be via the screen if the last input modality was touch, or voice in any other case.
- Modifies ControlManager to include overridable functions to evaluate input modality/response style, using the above defaults.
- Modifies ControlManager to provide functions for getting/setting attributes in state.
- Modifies ControlInput to include the preferred response style for a request, as well as the input modality history.
- Modifies ControlHandler to execute the above functions as part of the prepare() step, to track input modality history, and to construct ControlInput with the new attributes mentioned above.
- Introduces a utility function that conditionally adds voice prompt/reprompt fragments based on the preferred ResponseStyle.
- Modifies existing controls that support APL to use the above utility function.
- Modifies all existing acts to use the above utility function. This is a breaking change, because developers who are using these acts will no longer have voice prompts added if the user last responded using touch. I think this is warranted, however, given the following:
  - Built-in act render methods are intended as convenience methods to make Alexa "do the right thing" without granular control over the response
  - The [Alexa Design Guide](https://designguide.corp.amazon.com/en/alexa/foundation/trustbusters/) recommends that the developer should "Honor the user's modality, this will show that we respect how the user wants to interact: if an interaction was initiated by voice, respond with voice. If by touch, respond visually." "Doing the right thing" here means that we should abide by this guideline in the design guide.
  - It is currently being debated whether or not the built-in Act render() methods should remain supported, so this may end up being a moot point.

## Motivation and Context
Controls Framework aims to make building skills scalable and efficient. It includes a library of common controls intended to speed up parts of development. As it stands today, however, these common controls do not allow developers to abide by one of the suggestions in the Alexa Design Guide: "Honor the user's modality, this will show that we respect how the user wants to interact: if an interaction was initiated by voice, respond with voice. If by touch, respond visually."

These changes modify the default behavior of the common controls & acts to fix this. They also introduce new attributes and utilities to make it straightforward for developers to respect the Design Guide, while still offering them the ability to override the default behavior.

## Testing
- Existing tests involving user touch input in both the primary & demo modules were broken by these changes (as expected), and I modified the tests to account for this.
- All other tests still pass in VS Code & CLI
- E2E tests are included for determining input modality and output response style. These test the default evaluation functions, as well as the changes to ControlInput/ControlManager/ControlHandler
- Unit tests are included for the new utility function to verify that the appropriate prompts/reprompts are added based on input context. 

## Screenshots (if appropriate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs(Add new document content)
- [ ] Translate Docs(Translate document content)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License
- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

[issues]: https://https://github.com/alexa/ask-sdk-controls/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
