### PR TITLE
feat: Add support for CanFulfillIntentRequest

### DIFF
--- a/src/systemActs/ContentActs.ts
+++ b/src/systemActs/ContentActs.ts
@@ -24,6 +24,7 @@ import {
     ValueClearedPayload,
     ValueRemovedPayload,
     ValueSetPayload,
+    CanFulfillIntentPayload,
 } from './PayloadTypes';
 import { SystemAct } from './SystemAct';
 
@@ -408,5 +409,18 @@ export class InvalidRemoveValueAct<T> extends ContentAct {
                 value: this.payload.value,
             }),
         );
+    }
+}
+
+export class CanFulfillIntentAct extends ContentAct {
+    payload: CanFulfillIntentPayload;
+
+    constructor(control: Control, payload: CanFulfillIntentPayload) {
+        super(control);
+        this.payload = payload;
+    }
+
+    render(input: ControlInput, controlResponseBuilder: ControlResponseBuilder): void {
+        controlResponseBuilder.withCanFulfillIntent(this.payload.intent);
     }
 }

--- a/src/systemActs/PayloadTypes.ts
+++ b/src/systemActs/PayloadTypes.ts
@@ -10,6 +10,7 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+import { canfulfill } from 'ask-sdk-model';
 
 /**
  * Payload for ValueSetAct
@@ -183,4 +184,11 @@ export interface RequestRemovedValueByListActPayload {
 export interface LiteralContentPayload {
     promptFragment: string;
     repromptFragment?: string;
+}
+
+/**
+ * Payload for CanFulfillIntentAct
+ */
+export interface CanFulfillIntentPayload {
+    intent: canfulfill.CanFulfillIntent;
 }

--- a/src/utils/testSupport/TestingUtils.ts
+++ b/src/utils/testSupport/TestingUtils.ts
@@ -19,7 +19,15 @@ import {
     ResponseFactory,
     Skill,
 } from 'ask-sdk-core';
-import { Intent, IntentRequest, interfaces, LaunchRequest, Request, RequestEnvelope } from 'ask-sdk-model';
+import {
+    Intent,
+    IntentRequest,
+    interfaces,
+    LaunchRequest,
+    Request,
+    RequestEnvelope,
+    canfulfill,
+} from 'ask-sdk-model';
 import { expect } from 'chai';
 import _ from 'lodash';
 import { Control } from '../../controls/Control';
@@ -185,7 +193,10 @@ export async function testTurn(
     } else {
         const expectedPrompt: string =
             typeof expectedResponse === 'string' ? expectedResponse : expectedResponse.prompt;
-        if (!expectedPrompt.toLowerCase().startsWith('a:')) {
+        if (
+            !expectedPrompt.toLowerCase().startsWith('a:') &&
+            input.handlerInput.requestEnvelope.request.type !== 'CanFulfillIntentRequest'
+        ) {
             throw new Error(
                 `test configuration error: Alexa prompt should start with A: -->${expectedResponse}`,
             );
@@ -284,6 +295,24 @@ export class TestInput {
         };
 
         return dummyControlInput(userEvent);
+    }
+
+    public static canFulfillIntentRequest(
+        nameOrIntent: string | Intent,
+        slotValues?: { [k: string]: any },
+    ): ControlInput {
+        const intent =
+            typeof nameOrIntent === 'string' ? IntentBuilder.of(nameOrIntent, slotValues) : nameOrIntent;
+        const canFulfillIntentRequest: canfulfill.CanFulfillIntentRequest = {
+            type: 'CanFulfillIntentRequest',
+            requestId: makeRequestId(),
+            timestamp: '2020-10-19T18:46:20Z',
+            locale: 'en-US',
+            dialogState: 'STARTED',
+            intent,
+        };
+
+        return dummyControlInput(canFulfillIntentRequest);
     }
 }
 

--- a/test/systemActs/ContentActs.spec.ts
+++ b/test/systemActs/ContentActs.spec.ts
@@ -1,0 +1,88 @@
+import { suite, test } from 'mocha';
+import { ContainerControl } from '../../src/controls/ContainerControl';
+import { Control } from '../../src/controls/Control';
+import { ControlManager } from '../../src/controls/ControlManager';
+import { ControlHandler } from '../../src/runtime/ControlHandler';
+import { SkillInvoker, TestResponseObject } from '../../src/utils/testSupport/SkillInvoker';
+import { TestInput, testTurn } from '../../src/utils/testSupport/TestingUtils';
+import { ControlInput } from '../../src/controls/ControlInput';
+import { ControlResultBuilder } from '../../src/controls/ControlResult';
+import { CanFulfillIntentAct } from '../../src/systemActs/ContentActs';
+import { canfulfill } from 'ask-sdk-model';
+
+suite('Test CanFulfillIntentRequest', () => {
+    const canFulfillIntent: canfulfill.CanFulfillIntent = {
+        canFulfill: 'YES',
+        slots: {
+            Artist: {
+                canUnderstand: 'YES',
+                canFulfill: 'YES',
+            },
+            Song: {
+                canUnderstand: 'YES',
+                canFulfill: 'YES',
+            },
+            DedicatedPerson: {
+                canUnderstand: 'YES',
+                canFulfill: 'YES',
+            },
+        },
+    };
+    class TestControlManager extends ControlManager {
+        createControlTree(): Control {
+            return new CustomRootControl({ id: 'root' });
+        }
+    }
+
+    class CustomRootControl extends ContainerControl {
+        async canHandle(input: ControlInput): Promise<boolean> {
+            return input.request.type === 'CanFulfillIntentRequest';
+        }
+
+        async handle(input: ControlInput, resultBuilder: ControlResultBuilder): Promise<void> {
+            if (input.request.type === 'CanFulfillIntentRequest') {
+                resultBuilder.addAct(
+                    new CanFulfillIntentAct(this, {
+                        intent: canFulfillIntent,
+                    }),
+                );
+            }
+            return;
+        }
+    }
+
+    test('CanFulfillIntentRequest', async () => {
+        const requestHandler = new ControlHandler(new TestControlManager());
+        const invoker = new SkillInvoker(requestHandler);
+        const intentName = 'SendSongRequest';
+        const expectedResponse: TestResponseObject = {
+            responseEnvelope: {
+                version: '',
+                response: {
+                    canFulfillIntent,
+                },
+            },
+            prompt: '',
+        };
+        const slots = {
+            Artist: {
+                name: 'Artist',
+                confirmationStatus: 'NONE',
+            },
+            Song: {
+                name: 'Song',
+                confirmationStatus: 'NONE',
+            },
+            DedicatedPerson: {
+                name: 'DedicatedPerson',
+                confirmationStatus: 'NONE',
+            },
+        };
+        await testTurn(
+            invoker,
+            'U: __',
+            TestInput.canFulfillIntentRequest(intentName, slots),
+            expectedResponse,
+        );
+    });
+});


### PR DESCRIPTION
Add support for CanFulfillIntentRequest

## Description
Add new ContentAct of CanFulfillIntentAct to support response for CanFulfillIntentRequest.

## Motivation and Context
The CanFulfillIntentRequest support is required in dj-song-request component which uses Control Framework. Besides, it also provides support for CanFulfillIntentRequest for any future use.

## Testing
Test with a unit test in [commit in dj-song-request component](https://code.amazon.com/packages/AskIMESongRequestCustomSkillPOC/commits/973f52b464463f89fd86cc5277dd8cc21a34f914#test/CustomRootControl.spec.ts).

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs(Add new document content)
- [ ] Translate Docs(Translate document content)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License
- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

[issues]: https://https://github.com/alexa/ask-sdk-controls/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
