### PR TITLE
fix: elicit preposition slot

### DIFF
--- a/src/commonControls/ValueControl.ts
+++ b/src/commonControls/ValueControl.ts
@@ -1063,6 +1063,7 @@ export class ValueControl extends Control implements InteractionModelContributor
                 head: { name: 'head', value: '', confirmationStatus: 'NONE' },
                 tail: { name: 'tail', value: '', confirmationStatus: 'NONE' },
                 assign: { name: 'assign', value: '', confirmationStatus: 'NONE' },
+                preposition: { name: 'preposition', value: '', confirmationStatus: 'NONE' },
             },
             confirmationStatus: 'NONE',
         };


### PR DESCRIPTION
## Motivation and Context
The "preposition" slot is defined on intent samples generated by the ValueControl, but when eliciting values, it was missing.
Due to that, an error occurs with the following message:
"All slots must be defined when sending updated intent in the Dialog.ElicitSlot directive. Missing: Preposition"

This PR fixes that by including the "preposition" slot when generating the slots do be elicited.

## Testing
I've checked the tests, but both the test and the control uses the same function :)
That is my first time contributing, so I'm not sure on how granular the tests should be, but I can add one to the "ValueControl.generateSlotElicitationDetails" method.

## Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/25470308/133944879-4ba8a63e-f29d-48c8-bfed-623f751d662d.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs(Add new document content)
- [ ] Translate Docs(Translate document content)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License
- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

[issues]: https://https://github.com/alexa/ask-sdk-controls/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
